### PR TITLE
fix: preserve i64 seed precision

### DIFF
--- a/cg-arena-ui/src/components/ExampleSeedsDialog.tsx
+++ b/cg-arena-ui/src/components/ExampleSeedsDialog.tsx
@@ -4,20 +4,20 @@ import { Button, Modal, Table } from "react-bootstrap";
 import { FaCopy } from "react-icons/fa6";
 
 export interface ExampleSeedsDialogData {
-  example_seeds: number[];
+  example_seeds: string[];
 }
 
 const ExampleSeedsDialog = (dialog: DialogProps<ExampleSeedsDialogData>) => {
-  const [copied, setCopied] = useState<number>();
+  const [copied, setCopied] = useState<string>();
 
   const data = dialog.data;
   if (data === undefined) return null;
 
-  const copy = async (seed: number) => {
+  const copy = async (seed: string) => {
     await copyToClipboard(seed);
     setCopied(seed);
     setTimeout(() => {
-      setCopied((c) => (c == seed ? undefined : c));
+      setCopied((c) => (c === seed ? undefined : c));
     }, 3000);
   };
 
@@ -39,7 +39,7 @@ const ExampleSeedsDialog = (dialog: DialogProps<ExampleSeedsDialogData>) => {
             {data.example_seeds.map((seed, index) => (
               <tr key={index}>
                 <td>{index + 1}</td>
-                <td>{seed.toString()}</td>
+                <td>{seed}</td>
                 <td style={{ textAlign: "right" }}>
                   <Button
                     variant="outline-secondary"
@@ -63,9 +63,9 @@ const ExampleSeedsDialog = (dialog: DialogProps<ExampleSeedsDialogData>) => {
   );
 };
 
-const copyToClipboard = async (seed: number) => {
+const copyToClipboard = async (seed: string) => {
   try {
-    await navigator.clipboard.writeText(seed.toString());
+    await navigator.clipboard.writeText(seed);
   } catch (err) {
     console.error("Failed to copy text: " + err);
   }

--- a/cg-arena-ui/src/models/index.ts
+++ b/cg-arena-ui/src/models/index.ts
@@ -32,7 +32,7 @@ export interface LeaderboardOverviewResponse {
   items: LeaderboardItemResponse[];
   winrate_stats: WinrateStatsResponse[];
   total_matches: number;
-  example_seeds: number[];
+  example_seeds: string[];
 }
 
 export interface WinrateStatsResponse {
@@ -113,7 +113,7 @@ export interface FetchMatchesResponse {
 export interface MatchOverviewResponse {
   id: number;
   participants: ParticipantOverviewResponse[];
-  seed: number;
+  seed: string;
   attributes: MatchAttributeResponse[];
 }
 

--- a/src/api/routes/matches.rs
+++ b/src/api/routes/matches.rs
@@ -84,7 +84,7 @@ pub struct FetchMatchesResponse {
 pub struct MatchOverviewResponse {
     pub id: i64,
     pub participants: Vec<ParticipantOverviewResponse>,
-    pub seed: i64,
+    pub seed: String,
     pub attributes: Vec<MatchAttributeResponse>,
 }
 
@@ -119,7 +119,7 @@ impl From<MatchOverview> for MatchOverviewResponse {
         Self {
             id: value.id.into(),
             participants: value.participants.into_iter().map(Into::into).collect(),
-            seed: value.seed,
+            seed: value.seed.to_string(),
             attributes: value.attributes.into_iter().map(Into::into).collect(),
         }
     }
@@ -201,5 +201,21 @@ mod tests {
                 Err(ApiError::ValidationFailed(_))
             ));
         }
+    }
+    #[test]
+    fn serializes_i64_seed_without_precision_loss() {
+        let response = MatchOverviewResponse {
+            id: 1,
+            participants: vec![],
+            seed: i64::MAX.to_string(),
+            attributes: vec![],
+        };
+
+        let json = serde_json::to_value(response).unwrap();
+
+        assert_eq!(
+            json["seed"],
+            serde_json::Value::String(i64::MAX.to_string())
+        );
     }
 }


### PR DESCRIPTION
## Problem

Rust match seeds use `i64`, but the matches API serialized them as JSON numbers and the frontend modeled seeds as JavaScript `number`. Values outside JavaScript's safe integer range could be rounded silently. The example-seed frontend type also disagreed with its existing string wire format.

## Changes

- serialize match seeds as decimal JSON strings
- model match and example seeds as strings in the frontend
- display and copy seed strings without numeric conversion
- add regression coverage using `i64::MAX`

## Verification

- `cargo test api::routes::matches::tests`
- `npm run build` in `cg-arena-ui`
- `cargo fmt --check`