### PR TITLE
Deepen worker coordination module

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -5,18 +5,21 @@ use crate::domain::*;
 use crate::match_retrieval::MatchRetrieval;
 use crate::matchmaking;
 use crate::ranking::Ranker;
-use crate::worker::{BuildBotInput, PlayMatchBot, PlayMatchInput, PlayMatchOutput, WorkerHandle};
+use crate::worker::{
+    BuildBotInput, BuildBotOutput, BuildReconciliation, Completion, PlayMatchBot, PlayMatchInput,
+    PlayMatchOutput, Work, Worker, WorkerUnavailable,
+};
 use crate::{chart, db};
 use anyhow::{bail, Context};
 use itertools::Itertools;
 use sqlx::SqlitePool;
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::mpsc::error::{TryRecvError, TrySendError};
 use tokio::sync::mpsc::Receiver;
 use tokio::task::JoinHandle;
+use tokio::time::{Instant, MissedTickBehavior};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, instrument, warn};
 
@@ -27,10 +30,10 @@ pub async fn run(
     ranking_config: RankingConfig,
     pool: SqlitePool,
     arena_path: PathBuf,
-    worker_handle: WorkerHandle,
-    mut commands_rx: Receiver<ArenaCommand>,
+    worker: Worker,
+    commands_rx: Receiver<ArenaCommand>,
     cancellation_token: CancellationToken,
-) -> anyhow::Result<JoinHandle<()>> {
+) -> anyhow::Result<JoinHandle<anyhow::Result<()>>> {
     sqlx::migrate!()
         .run(&pool)
         .await
@@ -48,48 +51,79 @@ pub async fn run(
         ranker,
         arena_path,
         pool,
-        worker_handle,
     );
 
     arena
         .load_from_db()
         .await
         .context("Cannot load initial data from db")?;
-    arena.reset_stale_builds().await;
+    let reconciliation = worker.reconcile_builds(&arena.builds);
+    arena.apply_build_reconciliation(reconciliation).await;
     arena.recalculate_computed_full();
 
-    let task_handle = tokio::spawn(async move {
-        loop {
-            // check cancellation
-            if cancellation_token.is_cancelled() {
-                break;
-            }
+    Ok(tokio::spawn(run_loop(
+        arena,
+        worker,
+        commands_rx,
+        cancellation_token,
+    )))
+}
 
-            // handle commands
-            let disconnected = loop {
-                match commands_rx.try_recv() {
-                    Ok(cmd) => {
-                        arena.handle_command(cmd).await;
-                    }
-                    Err(TryRecvError::Empty) => break false,
-                    Err(TryRecvError::Disconnected) => break true,
-                }
-            };
-            if disconnected {
-                break;
-            }
+async fn run_loop(
+    mut arena: Arena,
+    worker: Worker,
+    mut commands_rx: Receiver<ArenaCommand>,
+    cancellation_token: CancellationToken,
+) -> anyhow::Result<()> {
+    let period = Duration::from_millis(50);
+    let mut chores = tokio::time::interval_at(Instant::now() + period, period);
+    chores.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    let mut scheduled_work = Vec::<Work>::new().into_iter();
+    let mut submission = None;
 
-            // time to let api return responses to clients
-            tokio::time::sleep(Duration::from_millis(50)).await;
-
-            if let Err(e) = arena.do_chores().await {
-                eprintln!("Arena error: {:#}", e);
-                eprintln!("Check logs for more details");
-                break;
+    loop {
+        if submission.is_none() {
+            if let Some(work) = scheduled_work.next() {
+                submission = Some(Box::pin(worker.submit(work)));
             }
         }
-    });
-    Ok(task_handle)
+
+        tokio::select! {
+            _ = cancellation_token.cancelled() => return Ok(()),
+            result = async {
+                submission
+                    .as_mut()
+                    .expect("guarded submission must exist")
+                    .await
+            }, if submission.is_some() => {
+                submission = None;
+                match result {
+                    Ok(()) => {}
+                    Err(WorkerUnavailable::ShuttingDown) => return Ok(()),
+                    Err(WorkerUnavailable::Failed(failure)) => return Err(failure.into()),
+                }
+            }
+            completion = worker.next() => {
+                match completion {
+                    Ok(completion) => arena.handle_worker_completion(completion).await,
+                    Err(WorkerUnavailable::ShuttingDown) => return Ok(()),
+                    Err(WorkerUnavailable::Failed(failure)) => return Err(failure.into()),
+                }
+            }
+            command = commands_rx.recv() => {
+                let Some(command) = command else {
+                    return Ok(());
+                };
+                arena.handle_command(command).await;
+            }
+            _ = chores.tick() => {
+                arena.let_leaderboards_catchup_with_live_matches();
+                if submission.is_none() && scheduled_work.len() == 0 {
+                    scheduled_work = arena.prepare_worker_work().await.into_iter();
+                }
+            }
+        }
+    }
 }
 
 struct Arena {
@@ -101,11 +135,9 @@ struct Arena {
     arena_path: PathBuf,
     bots: Vec<Bot>,
     builds: Vec<Build>,
-    worker_handle: WorkerHandle,
     ranker: Arc<Ranker>,
     global_leaderboard: AsyncLeaderboard,
     custom_leaderboards: Vec<AsyncLeaderboard>,
-    match_queue: VecDeque<PlayMatchInput>,
     scheduled_matches_total: HashMap<BotId, u64>,
     scheduled_matches_vs: HashMap<(BotId, BotId), u64>,
     matchmaking_enabled: bool,
@@ -119,7 +151,6 @@ impl Arena {
         ranker: Ranker,
         arena_path: PathBuf,
         pool: SqlitePool,
-        worker_handle: WorkerHandle,
     ) -> Self {
         let ranker = Arc::new(ranker);
         let match_retrieval = MatchRetrieval::new(pool.clone());
@@ -131,7 +162,6 @@ impl Arena {
             arena_path,
             pool,
             match_retrieval: match_retrieval.clone(),
-            worker_handle,
             ranker: Arc::clone(&ranker),
             bots: Default::default(),
             builds: Default::default(),
@@ -143,7 +173,6 @@ impl Arena {
             custom_leaderboards: Default::default(),
             scheduled_matches_total: Default::default(),
             scheduled_matches_vs: Default::default(),
-            match_queue: Default::default(),
         }
     }
 
@@ -166,103 +195,100 @@ impl Arena {
         Ok(())
     }
 
-    pub async fn do_chores(&mut self) -> anyhow::Result<()> {
-        self.run_builds().await;
-
-        if self.matchmaking_enabled {
-            self.perform_matchmaking()?;
-        }
-
-        self.send_matches_to_workers()?;
-
-        self.process_finished_matches().await;
-
-        self.let_leaderboards_catchup_with_live_matches();
-
-        Ok(())
-    }
-
-    pub async fn reset_stale_builds(&mut self) {
-        // any running builds should be reset on startup
-        for build in &mut self.builds {
-            if build.is_running() {
-                build.reset();
-                db::persist_build(&self.pool, build)
-                    .await
-                    .expect("Cannot persist build to DB");
-            }
-        }
-
-        // validate successful builds
-        for build in &mut self.builds {
-            let still_valid = self.worker_handle.known_bot_ids.contains(&build.bot_id);
-
-            if build.was_finished_successfully() && !still_valid {
-                build.reset();
-                db::persist_build(&self.pool, build)
-                    .await
-                    .expect("Cannot persist build to DB");
-            }
-        }
-    }
-
-    #[instrument(skip(self), level = "debug")]
-    pub async fn run_builds(&mut self) {
-        let mut inputs = Vec::new();
-        for bot in &mut self.bots {
-            for worker_name in std::iter::once(WorkerName::embedded()) {
-                let existing_build = self
-                    .builds
-                    .iter_mut()
-                    .find(|b| b.bot_id == bot.id && b.worker_name == worker_name);
-
-                let build = match existing_build {
-                    Some(build) if build.is_pending() => build,
-                    None => {
-                        self.builds.push(Build::new(bot.id, worker_name.clone()));
-                        self.builds.last_mut().unwrap()
-                    }
-                    _ => continue,
-                };
-
-                build.make_running();
-                db::persist_build(&self.pool, build)
-                    .await
-                    .expect("Cannot persist build to DB");
-                inputs.push(BuildBotInput {
-                    bot_id: bot.id,
-                    worker_name: worker_name.clone(),
-                    source_code: bot.source_code.clone(),
-                    language: bot.language.clone(),
-                })
-            }
-        }
-
-        for input in inputs {
-            let output = self.worker_handle.build_bot(input).await;
-            if !self.bots.iter_mut().any(|b| b.id == output.bot_id) {
-                warn!(
-                    "Obtained build result for non-existent bot, skipping. {:?}",
-                    output
-                );
-                continue;
-            }
-
+    async fn apply_build_reconciliation(&mut self, reconciliation: BuildReconciliation) {
+        for key in reconciliation.into_reset_builds() {
             let build = self
                 .builds
                 .iter_mut()
-                .find(|b| b.bot_id == output.bot_id && b.worker_name == output.worker_name);
-
-            let Some(build) = build else {
-                warn!("Obtained build result for non-existent build, skipping");
-                continue;
-            };
-
-            build.make_finished(output.result);
+                .find(|build| build.bot_id == key.bot_id && build.worker_name == key.worker_name)
+                .expect("worker reconciliation must reference a supplied build");
+            build.reset();
             db::persist_build(&self.pool, build)
                 .await
                 .expect("Cannot persist build to DB");
         }
+    }
+
+    async fn prepare_worker_work(&mut self) -> Vec<Work> {
+        let builds = self.prepare_build_work().await;
+        if !builds.is_empty() {
+            return builds.into_iter().map(Work::Build).collect();
+        }
+
+        if self.builds.iter().any(Build::is_running) || !self.matchmaking_enabled {
+            return Vec::new();
+        }
+
+        self.perform_matchmaking()
+            .into_iter()
+            .map(Work::Match)
+            .collect()
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    async fn prepare_build_work(&mut self) -> Vec<BuildBotInput> {
+        let mut inputs = Vec::new();
+        for bot in &mut self.bots {
+            let worker_name = WorkerName::embedded();
+            let existing_build = self
+                .builds
+                .iter_mut()
+                .find(|build| build.bot_id == bot.id && build.worker_name == worker_name);
+
+            let build = match existing_build {
+                Some(build) if build.is_pending() => build,
+                None => {
+                    self.builds.push(Build::new(bot.id, worker_name.clone()));
+                    self.builds.last_mut().expect("build was just inserted")
+                }
+                _ => continue,
+            };
+
+            build.make_running();
+            db::persist_build(&self.pool, build)
+                .await
+                .expect("Cannot persist build to DB");
+            inputs.push(BuildBotInput {
+                bot_id: bot.id,
+                worker_name,
+                source_code: bot.source_code.clone(),
+                language: bot.language.clone(),
+            });
+        }
+        inputs
+    }
+
+    async fn handle_worker_completion(&mut self, completion: Completion) {
+        match completion {
+            Completion::Build(output) => self.finish_build(output).await,
+            Completion::Match { input, output } => {
+                self.process_finished_match(&input, output).await;
+            }
+        }
+    }
+
+    async fn finish_build(&mut self, output: BuildBotOutput) {
+        if !self.bots.iter().any(|bot| bot.id == output.bot_id) {
+            warn!(
+                "Obtained build result for non-existent bot, skipping. {:?}",
+                output
+            );
+            return;
+        }
+
+        let build = self
+            .builds
+            .iter_mut()
+            .find(|build| build.bot_id == output.bot_id && build.worker_name == output.worker_name);
+        let Some(build) = build else {
+            warn!("Obtained build result for non-existent build, skipping");
+            return;
+        };
+
+        build.make_finished(output.result);
+        db::persist_build(&self.pool, build)
+            .await
+            .expect("Cannot persist build to DB");
     }
 
     async fn cmd_fetch_bot_source_code(&mut self, id: BotId) -> Option<BotSourceCode> {
@@ -606,40 +632,23 @@ impl Arena {
     }
 
     #[instrument(skip(self), level = "debug")]
-    pub fn perform_matchmaking(&mut self) -> anyhow::Result<()> {
+    fn perform_matchmaking(&mut self) -> Vec<PlayMatchInput> {
         // hardcoded for now
-        let mm_match_queue_size_threshold: usize = 20;
+        let match_batch_size: usize = 20;
+        let mut scheduled = Vec::new();
 
-        while self.match_queue.len() < mm_match_queue_size_threshold {
+        while scheduled.len() < match_batch_size {
             let new_matches = self.schedule_match();
             if new_matches.is_empty() {
                 break;
             }
-            for m in &new_matches {
-                self.record_scheduled_match(m);
+            for input in &new_matches {
+                self.record_scheduled_match(input);
             }
-            self.match_queue.extend(new_matches);
+            scheduled.extend(new_matches);
         }
 
-        Ok(())
-    }
-
-    pub fn send_matches_to_workers(&mut self) -> anyhow::Result<()> {
-        while let Some(input) = self.match_queue.pop_front() {
-            match self.worker_handle.match_tx.try_send(input) {
-                Ok(_) => {}
-                Err(TrySendError::Full(input)) => {
-                    self.match_queue.push_front(input);
-                    break;
-                }
-                Err(TrySendError::Closed(input)) => {
-                    self.match_queue.push_front(input);
-                    bail!("Cannot schedule a match, worker is closed.");
-                }
-            }
-        }
-
-        Ok(())
+        scheduled
     }
 
     #[instrument(skip(self), level = "debug")]
@@ -650,110 +659,113 @@ impl Arena {
         }
     }
 
-    #[instrument(skip(self), level = "debug")]
-    pub async fn process_finished_matches(&mut self) {
-        while let Ok(output) = self.worker_handle.match_result_rx.try_recv() {
-            self.forget_scheduled_match_result(&output);
-            let replay_path = output.replay_path.clone();
+    #[instrument(skip(self, input, output), level = "debug")]
+    async fn process_finished_match(&mut self, input: &PlayMatchInput, output: PlayMatchOutput) {
+        self.forget_scheduled_match(input);
+        let replay_path = output.replay_path.clone();
 
-            // validation
-            if output
-                .participants
-                .iter()
-                .any(|p| self.bots.iter().all(|b| b.id != p.bot_id))
-            {
-                warn!(
-                    "Match participant was deleted while match was running, ignoring match results"
-                );
-                if let Some(replay_path) = replay_path {
-                    if let Err(error) =
-                        crate::replay_artifact::remove(&self.arena_path, &replay_path).await
-                    {
-                        warn!("Cannot delete ignored replay artifact: {error:#}");
-                    }
+        if output
+            .participants
+            .iter()
+            .any(|participant| self.bots.iter().all(|bot| bot.id != participant.bot_id))
+        {
+            warn!("Match participant was deleted while match was running, ignoring match results");
+            if let Some(replay_path) = replay_path {
+                if let Err(error) =
+                    crate::replay_artifact::remove(&self.arena_path, &replay_path).await
+                {
+                    warn!("Cannot delete ignored replay artifact: {error:#}");
                 }
-                continue;
             }
+            return;
+        }
 
-            let attributes = output
-                .attributes
-                .into_iter()
-                .unique_by(|a| (a.name.clone(), a.bot_id, a.turn))
-                .collect();
+        let attributes = output
+            .attributes
+            .into_iter()
+            .unique_by(|attribute| (attribute.name.clone(), attribute.bot_id, attribute.turn))
+            .collect();
 
-            let mut new_match = Match::new(
-                output.seed,
-                output.participants,
-                attributes,
-                output.replay_path,
-            );
+        let mut new_match = Match::new(
+            output.seed,
+            output.participants,
+            attributes,
+            output.replay_path,
+        );
 
-            new_match.attributes.retain(|attr| attr.name != "seed");
+        new_match
+            .attributes
+            .retain(|attribute| attribute.name != "seed");
+        new_match.attributes.push(MatchAttribute {
+            name: "seed".to_string(),
+            bot_id: None,
+            turn: None,
+            value: MatchAttributeValue::Integer(output.seed),
+        });
+
+        new_match
+            .attributes
+            .retain(|attribute| attribute.name != "index");
+        new_match
+            .attributes
+            .retain(|attribute| attribute.name != "error");
+        new_match
+            .attributes
+            .retain(|attribute| attribute.name != "rank");
+
+        for (index, participant) in new_match.participants.iter().enumerate() {
             new_match.attributes.push(MatchAttribute {
-                name: "seed".to_string(),
-                bot_id: None,
+                name: "index".to_string(),
+                bot_id: Some(participant.bot_id),
                 turn: None,
-                value: MatchAttributeValue::Integer(output.seed),
+                value: MatchAttributeValue::Integer(index as _),
             });
 
-            new_match.attributes.retain(|attr| attr.name != "index");
-            new_match.attributes.retain(|attr| attr.name != "error");
-            new_match.attributes.retain(|attr| attr.name != "rank");
+            new_match.attributes.push(MatchAttribute {
+                name: "rank".to_string(),
+                bot_id: Some(participant.bot_id),
+                turn: None,
+                value: MatchAttributeValue::Integer(participant.rank as _),
+            });
 
-            for (index, p) in new_match.participants.iter().enumerate() {
+            if participant.error {
                 new_match.attributes.push(MatchAttribute {
-                    name: "index".to_string(),
-                    bot_id: Some(p.bot_id),
+                    name: "error".to_string(),
+                    bot_id: Some(participant.bot_id),
                     turn: None,
-                    value: MatchAttributeValue::Integer(index as _),
+                    value: MatchAttributeValue::Integer(1),
                 });
+            }
+        }
 
-                new_match.attributes.push(MatchAttribute {
-                    name: "rank".to_string(),
-                    bot_id: Some(p.bot_id),
-                    turn: None,
-                    value: MatchAttributeValue::Integer(p.rank as _),
-                });
+        if self.game_config.min_players != self.game_config.max_players {
+            new_match
+                .attributes
+                .retain(|attribute| attribute.name != "player_count");
+            new_match.attributes.push(MatchAttribute {
+                name: "player_count".to_string(),
+                bot_id: None,
+                turn: None,
+                value: MatchAttributeValue::Integer(new_match.participants.len() as _),
+            });
+        }
 
-                if p.error {
-                    new_match.attributes.push(MatchAttribute {
-                        name: "error".to_string(),
-                        bot_id: Some(p.bot_id),
-                        turn: None,
-                        value: MatchAttributeValue::Integer(1),
-                    });
+        if let Err(error) = db::persist_match(&self.pool, &mut new_match).await {
+            if let Some(replay_path) = &new_match.replay_path {
+                if let Err(cleanup_error) =
+                    crate::replay_artifact::remove(&self.arena_path, replay_path).await
+                {
+                    warn!("Cannot clean unpersisted replay artifact: {cleanup_error:#}");
                 }
             }
+            panic!("Cannot persist match to DB: {error:#}");
+        }
 
-            if self.game_config.min_players != self.game_config.max_players {
-                new_match
-                    .attributes
-                    .retain(|attr| attr.name != "player_count");
-                new_match.attributes.push(MatchAttribute {
-                    name: "player_count".to_string(),
-                    bot_id: None,
-                    turn: None,
-                    value: MatchAttributeValue::Integer(new_match.participants.len() as _),
-                });
-            }
-
-            if let Err(error) = db::persist_match(&self.pool, &mut new_match).await {
-                if let Some(replay_path) = &new_match.replay_path {
-                    if let Err(cleanup_error) =
-                        crate::replay_artifact::remove(&self.arena_path, replay_path).await
-                    {
-                        warn!("Cannot clean unpersisted replay artifact: {cleanup_error:#}");
-                    }
-                }
-                panic!("Cannot persist match to DB: {error:#}");
-            }
-
-            let m = Arc::new(new_match);
-
-            self.global_leaderboard.record_for_later(Arc::clone(&m));
-            for leaderboard in &mut self.custom_leaderboards {
-                leaderboard.record_for_later(Arc::clone(&m));
-            }
+        let new_match = Arc::new(new_match);
+        self.global_leaderboard
+            .record_for_later(Arc::clone(&new_match));
+        for leaderboard in &mut self.custom_leaderboards {
+            leaderboard.record_for_later(Arc::clone(&new_match));
         }
     }
 
@@ -853,32 +865,32 @@ impl Arena {
         }
     }
 
-    fn forget_scheduled_match_result(&mut self, output: &PlayMatchOutput) {
-        for participant in &output.participants {
+    fn forget_scheduled_match(&mut self, input: &PlayMatchInput) {
+        for bot in &input.bots {
             let entry = self
                 .scheduled_matches_total
-                .get_mut(&participant.bot_id)
+                .get_mut(&bot.bot_id)
                 .expect("finished match must have been scheduled");
             *entry -= 1;
             if *entry == 0 {
-                self.scheduled_matches_total.remove(&participant.bot_id);
+                self.scheduled_matches_total.remove(&bot.bot_id);
             }
         }
 
-        for participant in &output.participants {
-            for opp in &output.participants {
-                if participant.bot_id == opp.bot_id {
+        for bot in &input.bots {
+            for opponent in &input.bots {
+                if bot.bot_id == opponent.bot_id {
                     continue;
                 }
 
                 let entry = self
                     .scheduled_matches_vs
-                    .get_mut(&(participant.bot_id, opp.bot_id))
+                    .get_mut(&(bot.bot_id, opponent.bot_id))
                     .expect("finished match pair must have been scheduled");
                 *entry -= 1;
                 if *entry == 0 {
                     self.scheduled_matches_vs
-                        .remove(&(participant.bot_id, opp.bot_id));
+                        .remove(&(bot.bot_id, opponent.bot_id));
                 }
             }
         }

--- a/src/arena_server.rs
+++ b/src/arena_server.rs
@@ -48,36 +48,6 @@ pub async fn start(arena_path: &Path) -> anyhow::Result<()> {
         .await
         .context("Cannot connect to db")?;
     let token = CancellationToken::new();
-
-    let [WorkerConfig::Embedded(cfg)] = config.workers.as_slice() else {
-        bail!("In the current version only single embedded worker supported");
-    };
-    let worker_handle = worker::run_embedded_worker(arena_path, cfg.clone())
-        .context("Cannot start embedded worker")?;
-
-    let replay_viewer = ReplayViewer::new(
-        pool.clone(),
-        arena_path.to_owned(),
-        cfg.cmd_watch_replay.clone(),
-        token.clone(),
-    );
-
-    let (arena_tx, arena_rx) = tokio::sync::mpsc::channel(16);
-
-    let arena_task_handle = arena::run(
-        config.game,
-        config.matchmaking,
-        config.leaderboards,
-        config.ranking,
-        pool,
-        arena_path.to_owned(),
-        worker_handle,
-        arena_rx,
-        token.clone(),
-    )
-    .await
-    .context("Cannot start arena")?;
-
     let exposed = config.server.expose;
     let addr = if exposed {
         SocketAddr::from(([0, 0, 0, 0], config.server.port))
@@ -93,8 +63,51 @@ pub async fn start(arena_path: &Path) -> anyhow::Result<()> {
         .local_addr()
         .context("Cannot get local address of tcp binding")?;
 
+    let [WorkerConfig::Embedded(cfg)] = config.workers.as_slice() else {
+        bail!("In the current version only single embedded worker supported");
+    };
+    let worker::StartedWorker {
+        worker,
+        supervisor: worker_supervisor,
+    } = worker::start_embedded_worker(arena_path, cfg.clone())
+        .context("Cannot start embedded worker")?;
+
+    let replay_viewer = ReplayViewer::new(
+        pool.clone(),
+        arena_path.to_owned(),
+        cfg.cmd_watch_replay.clone(),
+        token.clone(),
+    );
+
+    let (arena_tx, arena_rx) = tokio::sync::mpsc::channel(16);
+
+    let mut arena_task_handle = match arena::run(
+        config.game,
+        config.matchmaking,
+        config.leaderboards,
+        config.ranking,
+        pool,
+        arena_path.to_owned(),
+        worker,
+        arena_rx,
+        token.clone(),
+    )
+    .await
+    {
+        Ok(task) => task,
+        Err(error) => {
+            token.cancel();
+            let worker_result = worker_supervisor.shutdown().await;
+            replay_viewer.shutdown().await;
+            if let Err(failure) = worker_result {
+                return Err(failure).context("Worker cleanup failed during arena startup");
+            }
+            return Err(error).context("Cannot start arena");
+        }
+    };
+
     let arena_handle = ArenaHandle::new(arena_tx);
-    let api_task_handle = tokio::spawn(api::start(
+    let mut api_task_handle = tokio::spawn(api::start(
         listener,
         arena_handle,
         replay_viewer.clone(),
@@ -111,23 +124,57 @@ pub async fn start(arena_path: &Path) -> anyhow::Result<()> {
     } else {
         println!("Network: use 'server.expose' config param to expose",);
     }
-    println!(); // empty line for nicer stdout
+    println!();
 
+    let mut arena_result = None;
+    let mut api_result = None;
+    let mut observed_worker_failure = None;
     tokio::select! {
         _ = shutdown_signal() => {
             println!("Stopping CG Arena... press Ctrl+C again to kill it");
         },
-        _ = arena_task_handle => {
-            warn!("Arena task terminated unexpectedly.");
+        failure = worker_supervisor.failed() => {
+            warn!("Embedded worker failed: {failure}");
+            observed_worker_failure = Some(failure);
         }
-        _ = api_task_handle => {
+        result = &mut arena_task_handle => {
+            warn!("Arena task terminated unexpectedly.");
+            arena_result = Some(result);
+        }
+        result = &mut api_task_handle => {
             warn!("API task terminated unexpectedly.");
+            api_result = Some(result);
         }
     }
+
     token.cancel();
+    let worker_result = worker_supervisor.shutdown().await;
     replay_viewer.shutdown().await;
+    let arena_result = match arena_result {
+        Some(result) => result,
+        None => arena_task_handle.await,
+    };
+    let api_result = match api_result {
+        Some(result) => result,
+        None => api_task_handle.await,
+    };
 
     info!("CG Arena stopped");
+
+    if let Err(failure) = worker_result {
+        return Err(failure.into());
+    }
+    if let Some(failure) = observed_worker_failure {
+        return Err(failure.into());
+    }
+    match arena_result {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => return Err(error).context("Arena task failed"),
+        Err(error) => return Err(error).context("Arena task terminated unexpectedly"),
+    }
+    if let Err(error) = api_result {
+        return Err(error).context("API task terminated unexpectedly");
+    }
 
     Ok(())
 }

--- a/src/arena_tests.rs
+++ b/src/arena_tests.rs
@@ -1,14 +1,16 @@
-use std::{ops::Deref, time::Duration};
+use std::{fs, ops::Deref, time::Duration};
 
 use crate::{
     arena_handle::ArenaHandle,
-    config::Config,
+    config::{Config, WorkerConfig},
     db,
     domain::*,
-    worker::{BuildBotInput, BuildBotOutput, PlayMatchOutput, WorkerHandle},
+    worker::{self, StartedWorker, WorkerSupervisor},
 };
 use chrono::{DateTime, Utc};
 use sqlx::{Row, SqlitePool};
+use tempfile::TempDir;
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use crate::arena::*;
@@ -18,49 +20,47 @@ struct TestArena {
     handle: ArenaHandle,
     cancellation_token: CancellationToken,
     pool: SqlitePool,
-    match_result_tx: tokio::sync::mpsc::Sender<PlayMatchOutput>,
+    _arena_path: TempDir,
+    _worker_supervisor: WorkerSupervisor,
+    _arena_task: JoinHandle<anyhow::Result<()>>,
 }
 
-async fn create_test_arena<F1>(config: Config, builder: F1) -> TestArena
-where
-    F1: Fn(BuildBotInput) -> BuildResult + Send + 'static,
-{
+async fn create_test_arena(mut config: Config, play_output: Option<&str>) -> TestArena {
+    let arena_path = tempfile::tempdir().unwrap();
+    let play_script = arena_path.path().join("play-match.sh");
+    let script = if let Some(output) = play_output {
+        let marker = arena_path.path().join("first-match");
+        format!(
+            "#!/bin/sh\nif mkdir '{}' 2>/dev/null; then\ncat <<'EOF'\n{output}\nEOF\nelse\nexec sleep 30\nfi\n",
+            marker.display()
+        )
+    } else {
+        "#!/bin/sh\nexec sleep 30\n".to_string()
+    };
+    fs::write(&play_script, script).unwrap();
+
+    let [WorkerConfig::Embedded(worker_config)] = config.workers.as_mut_slice() else {
+        panic!("tests require one embedded worker");
+    };
+    worker_config.cmd_build = "sh -c true".to_string();
+    worker_config.cmd_run = "true".to_string();
+    worker_config.cmd_play_match =
+        format!("sh {}", shell_words::quote(&play_script.to_string_lossy()));
+
+    let StartedWorker { worker, supervisor } =
+        worker::start_embedded_worker(arena_path.path(), worker_config.clone()).unwrap();
     let pool = db::in_memory().await.unwrap();
     let (commands_tx, commands_rx) = tokio::sync::mpsc::channel(16);
     let cancellation_token = CancellationToken::new();
-    let (match_result_tx, match_result_rx) = tokio::sync::mpsc::channel(100);
-    let (match_tx, mut match_rx) = tokio::sync::mpsc::channel(16);
-    let (build_tx, mut build_rx) = tokio::sync::mpsc::channel(1);
-    let worker_handle = WorkerHandle {
-        match_tx,
-        match_result_rx,
-        build_tx,
-        known_bot_ids: vec![],
-    };
-
-    tokio::spawn(async move {
-        while let Some(cmd) = build_rx.recv().await {
-            let output = BuildBotOutput {
-                bot_id: cmd.input.bot_id,
-                worker_name: cmd.input.worker_name.clone(),
-                result: builder(cmd.input),
-            };
-            cmd.result.send(output).unwrap();
-        }
-    });
-
-    // just dropping scheduled matches
-    tokio::spawn(async move { while (match_rx.recv().await).is_some() {} });
-
     let handle = ArenaHandle::new(commands_tx);
-    run(
+    let arena_task = run(
         config.game,
         config.matchmaking,
         config.leaderboards,
         config.ranking,
         pool.clone(),
-        Default::default(),
-        worker_handle,
+        arena_path.path().to_owned(),
+        worker,
         commands_rx,
         cancellation_token.clone(),
     )
@@ -71,14 +71,16 @@ where
         handle,
         cancellation_token,
         pool,
-        match_result_tx,
+        _arena_path: arena_path,
+        _worker_supervisor: supervisor,
+        _arena_task: arena_task,
     }
 }
 
 #[tokio::test]
 async fn cmd_create_bot_should_create_record_in_db() {
     let config = Config::default();
-    let arena = create_test_arena(config, |_| BuildResult::Success).await;
+    let arena = create_test_arena(config, None).await;
 
     let bot_name: BotName = String::from("Bot1").try_into().unwrap();
     let bot_source_code: SourceCode = String::from("some code").try_into().unwrap();
@@ -130,7 +132,7 @@ async fn cmd_create_bot_should_create_record_in_db() {
 #[tokio::test]
 async fn cmd_create_bot_should_fail_on_duplicate_name() {
     let config = Config::default();
-    let arena = create_test_arena(config, |_| BuildResult::Success).await;
+    let arena = create_test_arena(config, None).await;
 
     let bot_name: BotName = String::from("Bot1").try_into().unwrap();
     let bot_source_code: SourceCode = String::from("some code").try_into().unwrap();
@@ -166,7 +168,7 @@ async fn cmd_create_bot_should_fail_on_duplicate_name() {
 #[tokio::test]
 async fn cmd_rename_bot_works() {
     let config = Config::default();
-    let arena = create_test_arena(config, |_| BuildResult::Success).await;
+    let arena = create_test_arena(config, None).await;
 
     let bot_name: BotName = String::from("Bot1").try_into().unwrap();
     let bot_name_2: BotName = String::from("Bot2").try_into().unwrap();
@@ -205,7 +207,7 @@ async fn cmd_rename_bot_works() {
 #[tokio::test]
 async fn cmd_fetch_bot_source_code_works() {
     let config = Config::default();
-    let arena = create_test_arena(config, |_| BuildResult::Success).await;
+    let arena = create_test_arena(config, None).await;
 
     let bot_name: BotName = String::from("Bot1").try_into().unwrap();
     let bot_source_code: SourceCode = String::from("some code").try_into().unwrap();
@@ -237,7 +239,7 @@ async fn cmd_fetch_bot_source_code_works() {
 #[tokio::test]
 async fn cmd_rename_bot_fails_on_duplicate_name() {
     let config = Config::default();
-    let arena = create_test_arena(config, |_| BuildResult::Success).await;
+    let arena = create_test_arena(config, None).await;
 
     let bot_name: BotName = String::from("Bot1").try_into().unwrap();
     let bot_name_2: BotName = String::from("Bot2").try_into().unwrap();
@@ -280,7 +282,7 @@ async fn cmd_rename_bot_fails_on_duplicate_name() {
 #[tokio::test]
 async fn cmd_rename_bot_fails_if_no_bot_with_id() {
     let config = Config::default();
-    let arena = create_test_arena(config, |_| BuildResult::Success).await;
+    let arena = create_test_arena(config, None).await;
 
     let bot_id: BotId = 1i64.into();
     let bot_name: BotName = String::from("Bot1").try_into().unwrap();
@@ -295,7 +297,7 @@ async fn cmd_rename_bot_fails_if_no_bot_with_id() {
 #[tokio::test]
 async fn cmd_delete_bot_works() {
     let config = Config::default();
-    let arena = create_test_arena(config, |_| BuildResult::Success).await;
+    let arena = create_test_arena(config, None).await;
 
     let bot_name: BotName = String::from("Bot1").try_into().unwrap();
     let bot_source_code: SourceCode = String::from("some code").try_into().unwrap();
@@ -328,7 +330,7 @@ async fn cmd_delete_bot_works() {
 #[tokio::test]
 async fn cmd_fetch_leaderboard_works() {
     let config = Config::default();
-    let arena = create_test_arena(config, |_| BuildResult::Success).await;
+    let arena = create_test_arena(config, None).await;
 
     let bot_name_1: BotName = String::from("Bot1").try_into().unwrap();
     let bot_name_2: BotName = String::from("Bot2").try_into().unwrap();
@@ -361,7 +363,22 @@ async fn cmd_fetch_leaderboard_works() {
         panic!("Bot creation should succeed");
     };
 
-    let res3 = arena.handle.fetch_status().await.unwrap();
+    let res3 = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let status = arena.handle.fetch_status().await.unwrap();
+            if status.bots.len() == 2
+                && status
+                    .bots
+                    .iter()
+                    .all(|bot| bot.builds.len() == 1 && bot.builds[0].was_finished_successfully())
+            {
+                break status;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("real build completions should reach Arena");
 
     assert!(res3.matchmaking_enabled);
     assert_eq!(res3.bots.len(), 2);
@@ -410,8 +427,8 @@ async fn cmd_fetch_leaderboard_works() {
 #[tokio::test]
 async fn cmd_fetch_leaderboard_e2e() {
     let config = Config::default();
-
-    let arena = create_test_arena(config, |_| BuildResult::Success).await;
+    let match_output = r#"{"ranks":[0,1],"errors":[0,0]}"#;
+    let arena = create_test_arena(config, Some(match_output)).await;
 
     let bot_name_1: BotName = String::from("Bot1").try_into().unwrap();
     let bot_name_2: BotName = String::from("Bot2").try_into().unwrap();
@@ -447,84 +464,17 @@ async fn cmd_fetch_leaderboard_e2e() {
     let b1 = bot1.id;
     let b2 = bot2.id;
 
-    let fake_match_result = PlayMatchOutput {
-        seed: 1234,
-        participants: vec![
-            Participant {
-                bot_id: b1,
-                rank: 0,
-                error: false,
-            },
-            Participant {
-                bot_id: b2,
-                rank: 1,
-                error: false,
-            },
-        ],
-        attributes: {
-            let mut initial = vec![
-                MatchAttribute {
-                    name: "initial_stones".to_string(),
-                    bot_id: None,
-                    turn: None,
-                    value: "25".to_string().into(),
-                },
-                MatchAttribute {
-                    name: "map_type".to_string(),
-                    bot_id: None,
-                    turn: None,
-                    value: "small".to_string().into(),
-                },
-                MatchAttribute {
-                    name: "stones_percentage".to_string(),
-                    bot_id: None,
-                    turn: None,
-                    value: "0.75".to_string().into(),
-                },
-                MatchAttribute {
-                    name: "final_score".to_string(),
-                    bot_id: Some(b1),
-                    turn: None,
-                    value: "75".to_string().into(),
-                },
-                MatchAttribute {
-                    name: "final_score".to_string(),
-                    bot_id: Some(b2),
-                    turn: None,
-                    value: "50".to_string().into(),
-                },
-            ];
-
-            for turn in 0..=5 {
-                initial.push(MatchAttribute {
-                    name: "bombs_revealed".to_string(),
-                    bot_id: None,
-                    turn: Some(turn),
-                    value: (3 * turn).to_string().into(),
-                });
-                initial.push(MatchAttribute {
-                    name: "score".to_string(),
-                    bot_id: Some(b1),
-                    turn: Some(turn),
-                    value: (15 * turn).to_string().into(),
-                });
-                initial.push(MatchAttribute {
-                    name: "score".to_string(),
-                    bot_id: Some(b2),
-                    turn: Some(turn),
-                    value: (10 * turn).to_string().into(),
-                });
+    let res3 = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let status = arena.handle.fetch_status().await.unwrap();
+            if status.leaderboards[0].total_matches == 1 {
+                break status;
             }
-
-            initial
-        },
-        replay_path: None,
-    };
-    arena.match_result_tx.send(fake_match_result).await.unwrap();
-
-    tokio::time::sleep(Duration::from_millis(200)).await;
-
-    let res3 = arena.handle.fetch_status().await.unwrap();
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("a real worker completion should reach Arena");
 
     assert_eq!(res3.bots.len(), 2);
     assert_eq!(res3.bots[0].id, bot1.id);
@@ -541,17 +491,21 @@ async fn cmd_fetch_leaderboard_e2e() {
     let item1 = leaderboard.items.iter().find(|w| w.id == b1).unwrap();
     let item2 = leaderboard.items.iter().find(|w| w.id == b2).unwrap();
 
-    assert_eq!(item1.rank, 0);
-    assert_eq!(item2.rank, 1);
+    let (winner, loser, winner_id, loser_id) = if item1.rank == 0 {
+        (item1, item2, b1, b2)
+    } else {
+        (item2, item1, b2, b1)
+    };
+    assert_eq!(winner.rank, 0);
+    assert_eq!(loser.rank, 1);
+    assert!(winner.rating.score(3.0) > loser.rating.score(3.0));
 
-    assert!(item1.rating.score(3.0) > item2.rating.score(3.0));
-
-    assert_eq!(leaderboard.winrate_stats[&(bot1.id, bot2.id)].wins, 1);
-    assert_eq!(leaderboard.winrate_stats[&(bot1.id, bot2.id)].draws, 0);
-    assert_eq!(leaderboard.winrate_stats[&(bot1.id, bot2.id)].loses, 0);
-    assert_eq!(leaderboard.winrate_stats[&(bot2.id, bot1.id)].wins, 0);
-    assert_eq!(leaderboard.winrate_stats[&(bot2.id, bot1.id)].draws, 0);
-    assert_eq!(leaderboard.winrate_stats[&(bot2.id, bot1.id)].loses, 1);
+    assert_eq!(leaderboard.winrate_stats[&(winner_id, loser_id)].wins, 1);
+    assert_eq!(leaderboard.winrate_stats[&(winner_id, loser_id)].draws, 0);
+    assert_eq!(leaderboard.winrate_stats[&(winner_id, loser_id)].loses, 0);
+    assert_eq!(leaderboard.winrate_stats[&(loser_id, winner_id)].wins, 0);
+    assert_eq!(leaderboard.winrate_stats[&(loser_id, winner_id)].draws, 0);
+    assert_eq!(leaderboard.winrate_stats[&(loser_id, winner_id)].loses, 1);
 
     assert_eq!(leaderboard.total_matches, 1);
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -105,6 +105,9 @@ impl Config {
         }
         for config in &self.workers {
             let WorkerConfig::Embedded(config) = config;
+            if config.threads == 0 {
+                bail!("embedded worker must have at least one thread");
+            }
 
             if config.cmd_build.split_ascii_whitespace().count() == 0 {
                 bail!("cmd_build must not be blank");
@@ -215,6 +218,19 @@ mod test {
         assert!(
             result.is_err(),
             "Should fail because V2 is missing 'min_matches_per_pair'"
+        );
+    }
+    #[test]
+    fn zero_worker_threads_are_rejected() {
+        let mut config = Config::default();
+        let [WorkerConfig::Embedded(worker)] = config.workers.as_mut_slice() else {
+            panic!("default config must contain one embedded worker");
+        };
+        worker.threads = 0;
+
+        assert_eq!(
+            config.validate().unwrap_err().to_string(),
+            "embedded worker must have at least one thread"
         );
     }
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,68 +1,526 @@
 use crate::config::EmbeddedWorkerConfig;
 use crate::domain::{
-    BotId, BuildResult, Language, MatchAttribute, MatchAttributeValue, Participant, SourceCode,
-    WorkerName,
+    BotId, Build, BuildResult, Language, MatchAttribute, MatchAttributeValue, Participant,
+    SourceCode, WorkerName,
 };
 use anyhow::{bail, Context};
 use itertools::Itertools;
 use serde::Deserialize;
+use std::collections::HashSet;
+use std::future::Future;
 use std::path::{Path, PathBuf};
+use std::process::{ExitStatus, Output, Stdio};
 use std::sync::Arc;
+use tokio::io::AsyncReadExt;
+use tokio::process::Command;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
-use tokio::sync::{oneshot, Semaphore};
-use tokio::{fs, process::Command};
+use tokio::sync::{watch, Mutex};
+use tokio::task::{JoinHandle, JoinSet};
 use tokio_util::sync::CancellationToken;
-
-pub struct WorkerHandle {
-    pub match_tx: Sender<PlayMatchInput>,
-    pub match_result_rx: Receiver<PlayMatchOutput>,
-    pub build_tx: Sender<BuildCmd>,
-    pub known_bot_ids: Vec<BotId>,
-}
-
-impl WorkerHandle {
-    pub async fn build_bot(&self, input: BuildBotInput) -> BuildBotOutput {
-        let (tx, rx) = oneshot::channel();
-        let cmd = BuildCmd { input, result: tx };
-        let _ = self.build_tx.send(cmd).await;
-        rx.await.unwrap()
-    }
-}
-
-pub struct BuildCmd {
-    pub input: BuildBotInput,
-    pub result: oneshot::Sender<BuildBotOutput>,
-}
 
 const DIR_BOTS: &str = "bots";
 
-pub fn run_embedded_worker(
+/// The embedded worker's caller-facing execution interface.
+///
+/// Admission is bounded and waits for capacity. Completions are delivered in
+/// completion order. Queue topology, process ownership, and task lifecycle stay
+/// inside the worker module.
+pub struct Worker {
+    work_tx: Sender<Work>,
+    completion_rx: Mutex<Receiver<Completion>>,
+    state_rx: watch::Receiver<WorkerState>,
+    available_bot_ids: HashSet<BotId>,
+}
+
+/// Owns worker failure observation and orderly shutdown.
+///
+/// The server must retain this value and call [`WorkerSupervisor::shutdown`]
+/// before exiting.
+pub struct WorkerSupervisor {
+    cancellation_token: CancellationToken,
+    state_rx: watch::Receiver<WorkerState>,
+    task: Option<JoinHandle<Result<(), WorkerFailure>>>,
+}
+
+/// The two ownership views returned when the embedded worker starts.
+pub struct StartedWorker {
+    pub worker: Worker,
+    pub supervisor: WorkerSupervisor,
+}
+
+/// Work accepted by the embedded worker.
+pub enum Work {
+    Build(BuildBotInput),
+    Match(PlayMatchInput),
+}
+
+/// A completed worker operation.
+pub enum Completion {
+    Build(BuildBotOutput),
+    Match {
+        input: PlayMatchInput,
+        output: PlayMatchOutput,
+    },
+}
+
+/// Durable identity used to correlate a build with its worker.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BuildKey {
+    pub bot_id: BotId,
+    pub worker_name: WorkerName,
+}
+
+/// Startup build-state changes computed from the worker's private artifacts.
+pub struct BuildReconciliation {
+    reset_builds: Vec<BuildKey>,
+}
+
+impl BuildReconciliation {
+    pub fn into_reset_builds(self) -> Vec<BuildKey> {
+        self.reset_builds
+    }
+}
+
+/// A terminal worker coordination or match-execution failure.
+#[derive(Clone, Debug, thiserror::Error)]
+#[error("{message}")]
+pub struct WorkerFailure {
+    message: Arc<str>,
+}
+
+impl WorkerFailure {
+    fn new(error: impl std::fmt::Display) -> Self {
+        Self {
+            message: error.to_string().into(),
+        }
+    }
+}
+
+/// Why the worker can no longer accept or complete work.
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum WorkerUnavailable {
+    #[error("worker is shutting down")]
+    ShuttingDown,
+    #[error("worker failed: {0}")]
+    Failed(WorkerFailure),
+}
+
+#[derive(Clone, Debug)]
+enum WorkerState {
+    Running,
+    Stopping,
+    Stopped,
+    Failed(WorkerFailure),
+}
+
+/// Starts the concrete embedded worker and all supervised execution tasks.
+pub fn start_embedded_worker(
     worker_path: &Path,
     config: EmbeddedWorkerConfig,
-) -> anyhow::Result<WorkerHandle> {
-    let config = Arc::new(config);
+) -> anyhow::Result<StartedWorker> {
+    if config.threads == 0 {
+        bail!("embedded worker must have at least one thread");
+    }
 
-    let known_bot_ids = known_bot_ids(worker_path)?;
-
-    let (match_result_tx, match_result_rx) = channel(100);
-    let (match_tx, match_rx) = channel(config.threads as usize * 2);
-    tokio::spawn(run_play_matches(
-        match_rx,
+    let available_bot_ids = known_bot_ids(worker_path)?.into_iter().collect();
+    let capacity = usize::from(config.threads) * 2 + 1;
+    let (work_tx, work_rx) = channel(capacity);
+    let (completion_tx, completion_rx) = channel(capacity);
+    let (state_tx, state_rx) = watch::channel(WorkerState::Running);
+    let cancellation_token = CancellationToken::new();
+    let task = tokio::spawn(run_worker(
         worker_path.to_path_buf(),
-        Arc::clone(&config),
-        match_result_tx,
+        Arc::new(config),
+        work_rx,
+        completion_tx,
+        state_tx,
+        cancellation_token.clone(),
     ));
 
-    let (build_tx, build_rx) = channel(1);
-    tokio::spawn(run_build_bots(worker_path.to_path_buf(), config, build_rx));
+    Ok(StartedWorker {
+        worker: Worker {
+            work_tx,
+            completion_rx: Mutex::new(completion_rx),
+            state_rx: state_rx.clone(),
+            available_bot_ids,
+        },
+        supervisor: WorkerSupervisor {
+            cancellation_token,
+            state_rx,
+            task: Some(task),
+        },
+    })
+}
 
-    let handle = WorkerHandle {
-        match_tx,
-        match_result_rx,
-        build_tx,
-        known_bot_ids,
+impl Worker {
+    /// Returns the persisted builds that must be reset without exposing the
+    /// worker's filesystem inventory.
+    pub fn reconcile_builds(&self, builds: &[Build]) -> BuildReconciliation {
+        let reset_builds = builds
+            .iter()
+            .filter(|build| {
+                build.is_running()
+                    || (build.was_finished_successfully()
+                        && !self.available_bot_ids.contains(&build.bot_id))
+            })
+            .map(|build| BuildKey {
+                bot_id: build.bot_id,
+                worker_name: build.worker_name.clone(),
+            })
+            .collect();
+        BuildReconciliation { reset_builds }
+    }
+
+    /// Waits until `work` is admitted to the bounded worker backlog.
+    ///
+    /// Canceling the returned future before it resolves does not submit the
+    /// work. After `Ok(())`, the worker owns the work.
+    pub fn submit(
+        &self,
+        work: Work,
+    ) -> impl Future<Output = Result<(), WorkerUnavailable>> + Send + 'static {
+        let work_tx = self.work_tx.clone();
+        let mut state_rx = self.state_rx.clone();
+        async move {
+            if let Some(unavailable) = unavailable_state(&state_rx.borrow()) {
+                return Err(unavailable);
+            }
+
+            tokio::select! {
+                biased;
+                unavailable = wait_until_unavailable(&mut state_rx) => Err(unavailable),
+                result = work_tx.send(work) => result.map_err(|_| {
+                    unavailable_state(&state_rx.borrow()).unwrap_or(WorkerUnavailable::ShuttingDown)
+                }),
+            }
+        }
+    }
+
+    /// Waits for one completion without exposing or draining an internal
+    /// receiver. Only one `next` call may be outstanding.
+    pub async fn next(&self) -> Result<Completion, WorkerUnavailable> {
+        let mut completion_rx = self.completion_rx.lock().await;
+        let mut state_rx = self.state_rx.clone();
+
+        if let Some(unavailable) = unavailable_state(&state_rx.borrow()) {
+            return Err(unavailable);
+        }
+
+        tokio::select! {
+            completion = completion_rx.recv() => match completion {
+                Some(completion) => Ok(completion),
+                None => Err(
+                    unavailable_state(&state_rx.borrow())
+                        .unwrap_or_else(|| WorkerUnavailable::Failed(WorkerFailure::new(
+                            "worker completion stream closed unexpectedly",
+                        ))),
+                ),
+            },
+            unavailable = wait_until_unavailable(&mut state_rx) => Err(unavailable),
+        }
+    }
+}
+
+impl WorkerSupervisor {
+    /// Resolves when the worker enters a terminal failed state.
+    pub async fn failed(&self) -> WorkerFailure {
+        let mut state_rx = self.state_rx.clone();
+        loop {
+            let state = state_rx.borrow().clone();
+            match state {
+                WorkerState::Failed(failure) => return failure,
+                WorkerState::Stopped => std::future::pending::<()>().await,
+                WorkerState::Running | WorkerState::Stopping => {}
+            }
+            if state_rx.changed().await.is_err() {
+                return WorkerFailure::new("worker task terminated unexpectedly");
+            }
+        }
+    }
+
+    /// Rejects new work, cancels queued and running work, reaps child
+    /// processes, and joins every worker task.
+    pub async fn shutdown(mut self) -> Result<(), WorkerFailure> {
+        self.cancellation_token.cancel();
+        let task = self.task.take().expect("worker task must be owned");
+        match task.await {
+            Ok(result) => result,
+            Err(error) => Err(WorkerFailure::new(format!(
+                "worker task terminated unexpectedly: {error}"
+            ))),
+        }
+    }
+}
+
+impl Drop for WorkerSupervisor {
+    fn drop(&mut self) {
+        self.cancellation_token.cancel();
+    }
+}
+
+fn unavailable_state(state: &WorkerState) -> Option<WorkerUnavailable> {
+    match state {
+        WorkerState::Running => None,
+        WorkerState::Stopping | WorkerState::Stopped => Some(WorkerUnavailable::ShuttingDown),
+        WorkerState::Failed(failure) => Some(WorkerUnavailable::Failed(failure.clone())),
+    }
+}
+
+async fn wait_until_unavailable(state_rx: &mut watch::Receiver<WorkerState>) -> WorkerUnavailable {
+    loop {
+        if let Some(unavailable) = unavailable_state(&state_rx.borrow()) {
+            return unavailable;
+        }
+        if state_rx.changed().await.is_err() {
+            return WorkerUnavailable::Failed(WorkerFailure::new(
+                "worker task terminated unexpectedly",
+            ));
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum WorkKind {
+    Build,
+    Match,
+}
+
+struct FinishedWork {
+    kind: WorkKind,
+    result: Result<(), WorkerFailure>,
+}
+
+enum StopReason {
+    Shutdown,
+    Failed(WorkerFailure),
+}
+
+async fn run_worker(
+    worker_path: PathBuf,
+    config: Arc<EmbeddedWorkerConfig>,
+    mut work_rx: Receiver<Work>,
+    completion_tx: Sender<Completion>,
+    state_tx: watch::Sender<WorkerState>,
+    cancellation_token: CancellationToken,
+) -> Result<(), WorkerFailure> {
+    let execution_token = CancellationToken::new();
+    let mut tasks = JoinSet::new();
+    let mut pending_work = None;
+    let mut build_running = false;
+    let mut matches_running = 0usize;
+
+    let stop_reason = 'running: loop {
+        if pending_work
+            .as_ref()
+            .is_some_and(|work| can_start(work, build_running, matches_running, &config))
+        {
+            let work = pending_work.take().expect("pending work must exist");
+            match &work {
+                Work::Build(_) => build_running = true,
+                Work::Match(_) => matches_running += 1,
+            }
+            spawn_work(
+                &mut tasks,
+                worker_path.clone(),
+                Arc::clone(&config),
+                completion_tx.clone(),
+                execution_token.clone(),
+                work,
+            );
+            continue;
+        }
+
+        tokio::select! {
+            biased;
+            _ = cancellation_token.cancelled() => break StopReason::Shutdown,
+            result = tasks.join_next(), if !tasks.is_empty() => {
+                match result {
+                    Some(Ok(finished)) => {
+                        match finished.kind {
+                            WorkKind::Build => build_running = false,
+                            WorkKind::Match => matches_running -= 1,
+                        }
+                        if let Err(failure) = finished.result {
+                            state_tx.send_replace(WorkerState::Failed(failure.clone()));
+                            break 'running StopReason::Failed(failure);
+                        }
+                    }
+                    Some(Err(error)) => {
+                        let failure = WorkerFailure::new(format!(
+                            "worker execution task terminated unexpectedly: {error}"
+                        ));
+                        state_tx.send_replace(WorkerState::Failed(failure.clone()));
+                        break 'running StopReason::Failed(failure);
+                    }
+                    None => {}
+                }
+            }
+            work = work_rx.recv(), if pending_work.is_none() => {
+                match work {
+                    Some(work) => pending_work = Some(work),
+                    None => break StopReason::Shutdown,
+                }
+            }
+        }
     };
-    Ok(handle)
+
+    work_rx.close();
+    drop(pending_work);
+    while work_rx.try_recv().is_ok() {}
+
+    if matches!(stop_reason, StopReason::Shutdown) {
+        state_tx.send_replace(WorkerState::Stopping);
+    }
+    execution_token.cancel();
+
+    let mut cleanup_failure = None;
+    while let Some(result) = tasks.join_next().await {
+        match result {
+            Ok(FinishedWork {
+                result: Err(failure),
+                ..
+            }) if cleanup_failure.is_none() => cleanup_failure = Some(failure),
+            Err(error) if cleanup_failure.is_none() => {
+                cleanup_failure = Some(WorkerFailure::new(format!(
+                    "worker execution task terminated unexpectedly: {error}"
+                )));
+            }
+            _ => {}
+        }
+    }
+    drop(completion_tx);
+
+    let failure = match stop_reason {
+        StopReason::Failed(failure) => Some(failure),
+        StopReason::Shutdown => cleanup_failure,
+    };
+    if let Some(failure) = failure {
+        state_tx.send_replace(WorkerState::Failed(failure.clone()));
+        Err(failure)
+    } else {
+        state_tx.send_replace(WorkerState::Stopped);
+        Ok(())
+    }
+}
+
+fn can_start(
+    work: &Work,
+    build_running: bool,
+    matches_running: usize,
+    config: &EmbeddedWorkerConfig,
+) -> bool {
+    match work {
+        Work::Build(_) => !build_running,
+        Work::Match(_) => matches_running < usize::from(config.threads),
+    }
+}
+
+fn spawn_work(
+    tasks: &mut JoinSet<FinishedWork>,
+    worker_path: PathBuf,
+    config: Arc<EmbeddedWorkerConfig>,
+    completion_tx: Sender<Completion>,
+    cancellation_token: CancellationToken,
+    work: Work,
+) {
+    tasks.spawn(async move {
+        match work {
+            Work::Build(input) => {
+                let result = if let Some(output) =
+                    execute_build(worker_path, config, input, cancellation_token.clone()).await
+                {
+                    publish_completion(
+                        &completion_tx,
+                        Completion::Build(output),
+                        &cancellation_token,
+                    )
+                    .await;
+                    Ok(())
+                } else {
+                    Ok(())
+                };
+                FinishedWork {
+                    kind: WorkKind::Build,
+                    result,
+                }
+            }
+            Work::Match(input) => {
+                let result =
+                    match execute_match(worker_path, config, input, cancellation_token.clone())
+                        .await
+                    {
+                        Ok(Some(completion)) => {
+                            publish_completion(&completion_tx, completion, &cancellation_token)
+                                .await;
+                            Ok(())
+                        }
+                        Ok(None) => Ok(()),
+                        Err(failure) => Err(failure),
+                    };
+                FinishedWork {
+                    kind: WorkKind::Match,
+                    result,
+                }
+            }
+        }
+    });
+}
+
+async fn publish_completion(
+    completion_tx: &Sender<Completion>,
+    completion: Completion,
+    cancellation_token: &CancellationToken,
+) -> bool {
+    tokio::select! {
+        biased;
+        _ = cancellation_token.cancelled() => false,
+        result = completion_tx.send(completion) => result.is_ok(),
+    }
+}
+
+async fn execute_build(
+    worker_path: PathBuf,
+    config: Arc<EmbeddedWorkerConfig>,
+    input: BuildBotInput,
+    cancellation_token: CancellationToken,
+) -> Option<BuildBotOutput> {
+    let bot_id = input.bot_id;
+    let worker_name = input.worker_name.clone();
+    let result = match build_bot(worker_path, config, input, &cancellation_token).await {
+        Ok(Some(result)) => result,
+        Ok(None) => return None,
+        Err(error) => BuildResult::Failure {
+            stderr: format!("{error:#}"),
+        },
+    };
+    Some(BuildBotOutput {
+        bot_id,
+        worker_name,
+        result,
+    })
+}
+
+async fn execute_match(
+    worker_path: PathBuf,
+    config: Arc<EmbeddedWorkerConfig>,
+    input: PlayMatchInput,
+    cancellation_token: CancellationToken,
+) -> Result<Option<Completion>, WorkerFailure> {
+    if cancellation_token.is_cancelled() {
+        return Ok(None);
+    }
+    let (command_parts, replay_path) =
+        prepare_play_match_command(&config, &input).map_err(WorkerFailure::new)?;
+    let output = spawn_play_match_command(
+        command_parts,
+        replay_path,
+        worker_path,
+        &input,
+        &cancellation_token,
+    )
+    .await
+    .map_err(|error| WorkerFailure::new(format!("{error:#}")))?;
+    Ok(output.map(|output| Completion::Match { input, output }))
 }
 
 fn known_bot_ids(worker_path: &Path) -> anyhow::Result<Vec<BotId>> {
@@ -95,47 +553,32 @@ fn known_bot_ids(worker_path: &Path) -> anyhow::Result<Vec<BotId>> {
     Ok(res)
 }
 
-async fn run_build_bots(
-    worker_path: PathBuf,
-    config: Arc<EmbeddedWorkerConfig>,
-    mut rx: Receiver<BuildCmd>,
-) {
-    while let Some(cmd) = rx.recv().await {
-        let bot_id = cmd.input.bot_id;
-        let worker_name = cmd.input.worker_name.clone();
-
-        let result = build_bot(worker_path.clone(), Arc::clone(&config), cmd.input)
-            .await
-            .unwrap_or_else(|e| BuildResult::Failure {
-                stderr: e.to_string(),
-            });
-
-        let output = BuildBotOutput {
-            bot_id,
-            worker_name,
-            result,
-        };
-        let _ = cmd.result.send(output);
-    }
-}
-
 async fn build_bot(
     worker_path: PathBuf,
     config: Arc<EmbeddedWorkerConfig>,
     input: BuildBotInput,
-) -> anyhow::Result<BuildResult> {
+    cancellation_token: &CancellationToken,
+) -> anyhow::Result<Option<BuildResult>> {
+    if cancellation_token.is_cancelled() {
+        return Ok(None);
+    }
+
     let bot_folder_relative = PathBuf::from(DIR_BOTS).join(i64::from(input.bot_id).to_string());
     let bot_folder = worker_path.join(&bot_folder_relative);
 
-    fs::create_dir_all(&bot_folder)
+    tokio::fs::create_dir_all(&bot_folder)
         .await
         .context("Failed to create bot folder")?;
-    fs::write(
+    tokio::fs::write(
         bot_folder.join("source.txt"),
         &String::from(input.source_code),
     )
     .await
     .context("Cannot create source.txt file")?;
+
+    if cancellation_token.is_cancelled() {
+        return Ok(None);
+    }
 
     let dir_param_value = bot_folder_relative
         .to_str()
@@ -145,72 +588,95 @@ async fn build_bot(
         .replace("{DIR}", dir_param_value)
         .replace("{LANG}", &input.language)
         .split_ascii_whitespace()
-        .map(|s| s.to_string())
+        .map(str::to_owned)
         .collect_vec();
-    assert_ne!(command_parts.len(), 0);
+    if command_parts.is_empty() {
+        bail!("cmd_build must not be blank");
+    }
 
-    let output = Command::new(&command_parts[0])
-        .args(&command_parts[1..])
-        .current_dir(&worker_path)
-        .output()
-        .await
-        .context("Failed to execute command")?;
-
-    let res = if output.status.success() {
+    let Some(output) = run_command(command_parts, &worker_path, cancellation_token).await? else {
+        return Ok(None);
+    };
+    Ok(Some(if output.status.success() {
         BuildResult::Success
     } else {
         BuildResult::Failure {
             stderr: String::from_utf8_lossy(&output.stderr).to_string(),
         }
-    };
-    Ok(res)
+    }))
 }
 
-async fn run_play_matches(
-    mut rx: Receiver<PlayMatchInput>,
-    worker_path: PathBuf,
-    config: Arc<EmbeddedWorkerConfig>,
-    match_result_tx: Sender<PlayMatchOutput>,
-) {
-    let semaphore = Arc::new(Semaphore::new(config.threads as usize));
-    let token = CancellationToken::new();
+async fn run_command(
+    command_parts: Vec<String>,
+    current_dir: &Path,
+    cancellation_token: &CancellationToken,
+) -> anyhow::Result<Option<Output>> {
+    let program = command_parts.first().context("command must not be blank")?;
+    let mut command = Command::new(program);
+    command
+        .args(&command_parts[1..])
+        .current_dir(current_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    let mut child = command.spawn().context("failed to spawn command")?;
+    let mut stdout = child
+        .stdout
+        .take()
+        .context("command stdout must be piped")?;
+    let mut stderr = child
+        .stderr
+        .take()
+        .context("command stderr must be piped")?;
+    let stdout_task = tokio::spawn(async move {
+        let mut bytes = Vec::new();
+        stdout.read_to_end(&mut bytes).await?;
+        Ok::<_, std::io::Error>(bytes)
+    });
+    let stderr_task = tokio::spawn(async move {
+        let mut bytes = Vec::new();
+        stderr.read_to_end(&mut bytes).await?;
+        Ok::<_, std::io::Error>(bytes)
+    });
 
-    while let Some(input) = rx.recv().await {
-        if token.is_cancelled() {
-            break;
+    let status: anyhow::Result<Option<ExitStatus>> = tokio::select! {
+        result = child.wait() => result.context("failed to wait for command").map(Some),
+        _ = cancellation_token.cancelled() => {
+            let kill_result = child
+                .start_kill()
+                .or_else(|error| {
+                    if error.kind() == std::io::ErrorKind::InvalidInput {
+                        Ok(())
+                    } else {
+                        Err(error)
+                    }
+                })
+                .context("failed to terminate canceled command");
+            let wait_result = child
+                .wait()
+                .await
+                .context("failed to reap canceled command");
+            match (kill_result, wait_result) {
+                (Err(error), _) | (_, Err(error)) => Err(error),
+                (Ok(()), Ok(_)) => Ok(None),
+            }
         }
+    };
 
-        let (command_parts, replay_path) = match prepare_play_match_command(&config, &input) {
-            Ok(command) => command,
-            Err(error) => {
-                token.cancel();
-                tracing::error!("{error:#}");
-                break;
-            }
-        };
+    let stdout = stdout_task
+        .await
+        .context("stdout reader task terminated unexpectedly")?
+        .context("failed to read command stdout")?;
+    let stderr = stderr_task
+        .await
+        .context("stderr reader task terminated unexpectedly")?
+        .context("failed to read command stderr")?;
 
-        let semaphore = Arc::clone(&semaphore);
-        let permit = semaphore.acquire_owned().await.expect("Semaphore poisoned");
-        let match_result_tx_clone = match_result_tx.clone();
-        let worker_path_clone = worker_path.clone();
-        let token_clone = token.clone();
-        tokio::spawn(async move {
-            let res =
-                spawn_play_match_command(command_parts, replay_path, worker_path_clone, input)
-                    .await;
-
-            match res {
-                Ok(output) => {
-                    let _ = match_result_tx_clone.send(output).await;
-                }
-                Err(e) => {
-                    token_clone.cancel(); // this should make cgarena stop eventually
-                    tracing::error!("{}", e);
-                }
-            }
-            drop(permit);
-        });
-    }
+    Ok(status?.map(|status| Output {
+        status,
+        stdout,
+        stderr,
+    }))
 }
 
 fn prepare_play_match_command(
@@ -286,25 +752,24 @@ async fn spawn_play_match_command(
     command_parts: Vec<String>,
     replay_path: Option<PathBuf>,
     worker_path: PathBuf,
-    input: PlayMatchInput,
-) -> anyhow::Result<PlayMatchOutput> {
+    input: &PlayMatchInput,
+    cancellation_token: &CancellationToken,
+) -> anyhow::Result<Option<PlayMatchOutput>> {
     let absolute_replay_path = replay_path
         .as_ref()
         .map(|path| crate::replay_artifact::resolve(&worker_path, path))
         .transpose()?;
     if let Some(parent) = absolute_replay_path.as_ref().and_then(|path| path.parent()) {
-        fs::create_dir_all(parent)
+        tokio::fs::create_dir_all(parent)
             .await
             .context("cannot create replay directory")?;
     }
 
     let result = async {
-        let cmd_output = Command::new(&command_parts[0])
-            .args(&command_parts[1..])
-            .current_dir(&worker_path)
-            .output()
-            .await
-            .context("Error while executing cmd_play_match")?;
+        let Some(cmd_output) = run_command(command_parts, &worker_path, cancellation_token).await?
+        else {
+            return Ok(None);
+        };
 
         let result = if cmd_output.status.success() {
             let stdout =
@@ -318,8 +783,36 @@ async fn spawn_play_match_command(
             );
         };
 
+        let bot_count = input.bots.len();
+        if result.ranks.len() != bot_count {
+            bail!(
+                "play match output has {} ranks for {bot_count} bots",
+                result.ranks.len()
+            );
+        }
+        if result.errors.len() != bot_count {
+            bail!(
+                "play match output has {} errors for {bot_count} bots",
+                result.errors.len()
+            );
+        }
+        if !result.scores.is_empty() && result.scores.len() != bot_count {
+            bail!(
+                "play match output has {} scores for {bot_count} bots",
+                result.scores.len()
+            );
+        }
+        if let Some(player) = result
+            .attributes
+            .iter()
+            .filter_map(|attribute| attribute.player)
+            .find(|player| *player >= bot_count)
+        {
+            bail!("play match output references missing player {player}");
+        }
+
         let persisted_replay_path = if let Some(path) = &absolute_replay_path {
-            match fs::metadata(path).await {
+            match tokio::fs::metadata(path).await {
                 Ok(metadata) if metadata.is_file() && metadata.len() > 0 => replay_path.clone(),
                 Ok(_) => {
                     tracing::warn!("match command produced an empty replay artifact");
@@ -335,46 +828,46 @@ async fn spawn_play_match_command(
             None
         };
 
-        Ok(PlayMatchOutput {
+        Ok(Some(PlayMatchOutput {
             seed: input.seed,
             participants: input
                 .bots
                 .iter()
-                .zip_eq(result.ranks)
-                .zip_eq(result.errors)
-                .map(|((b, r), e)| Participant {
-                    bot_id: b.bot_id,
-                    rank: r,
-                    error: e == 1,
+                .zip(result.ranks)
+                .zip(result.errors)
+                .map(|((bot, rank), error)| Participant {
+                    bot_id: bot.bot_id,
+                    rank,
+                    error: error == 1,
                 })
                 .collect(),
             attributes: result
                 .attributes
                 .into_iter()
-                .map(|attr| to_match_attribute(&input, attr))
+                .map(|attribute| to_match_attribute(input, attribute))
                 .chain(if result.scores.is_empty() {
                     vec![].into_iter()
                 } else {
                     input
                         .bots
                         .iter()
-                        .zip_eq(result.scores)
-                        .map(|(b, s)| MatchAttribute {
+                        .zip(result.scores)
+                        .map(|(bot, score)| MatchAttribute {
                             name: "score".to_string(),
-                            bot_id: Some(b.bot_id),
+                            bot_id: Some(bot.bot_id),
                             turn: None,
-                            value: MatchAttributeValue::Integer(s as _),
+                            value: MatchAttributeValue::Integer(score as _),
                         })
                         .collect_vec()
                         .into_iter()
                 })
                 .collect(),
             replay_path: persisted_replay_path,
-        })
+        }))
     }
     .await;
 
-    if result.is_err() {
+    if !matches!(&result, Ok(Some(_))) {
         if let Some(path) = replay_path {
             if let Err(error) = crate::replay_artifact::remove(&worker_path, &path).await {
                 tracing::warn!("cannot clean failed replay artifact: {error:#}");
@@ -450,17 +943,36 @@ fn to_match_attribute(input: &PlayMatchInput, attr: CmdMatchAttribute) -> MatchA
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::time::Duration;
 
-    #[test]
-    fn same_seed_match_executions_receive_distinct_replay_paths() {
-        let config = EmbeddedWorkerConfig {
-            threads: 2,
-            cmd_play_match: "runner {SEED} {REPLAY_PATH} {P1} {P2}".to_string(),
-            cmd_watch_replay: "viewer".to_string(),
-            cmd_build: "builder".to_string(),
-            cmd_run: "bot {DIR}".to_string(),
-        };
-        let input = PlayMatchInput {
+    fn config(cmd_build: String, cmd_play_match: String) -> EmbeddedWorkerConfig {
+        EmbeddedWorkerConfig {
+            threads: 1,
+            cmd_play_match,
+            cmd_watch_replay: "true".to_string(),
+            cmd_build,
+            cmd_run: "true".to_string(),
+        }
+    }
+
+    fn script(directory: &Path, name: &str, body: &str) -> String {
+        let path = directory.join(name);
+        fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+        format!("sh {}", shell_words::quote(&path.to_string_lossy()))
+    }
+
+    fn build_input(bot_id: i64) -> BuildBotInput {
+        BuildBotInput {
+            bot_id: BotId::from(bot_id),
+            worker_name: WorkerName::embedded(),
+            source_code: "source".to_string().try_into().unwrap(),
+            language: "rust".to_string().try_into().unwrap(),
+        }
+    }
+
+    fn match_input(seed: i64) -> PlayMatchInput {
+        PlayMatchInput {
             bots: vec![
                 PlayMatchBot {
                     bot_id: BotId::from(1),
@@ -471,19 +983,183 @@ mod tests {
                     language: "rust".to_string().try_into().unwrap(),
                 },
             ],
-            seed: 42,
+            seed,
+        }
+    }
+
+    #[tokio::test]
+    async fn reconciliation_returns_only_builds_that_must_be_reset() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::create_dir_all(directory.path().join("bots/1")).unwrap();
+        fs::create_dir_all(directory.path().join("bots/5")).unwrap();
+        let StartedWorker { worker, supervisor } = start_embedded_worker(
+            directory.path(),
+            config("true".to_string(), "true".to_string()),
+        )
+        .unwrap();
+
+        let mut running = Build::new(BotId::from(1), WorkerName::embedded());
+        running.make_running();
+        let mut missing_success = Build::new(BotId::from(2), WorkerName::embedded());
+        missing_success.make_running();
+        missing_success.make_finished(BuildResult::Success);
+        let mut failed = Build::new(BotId::from(3), WorkerName::embedded());
+        failed.make_running();
+        failed.make_finished(BuildResult::Failure {
+            stderr: "expected".to_string(),
+        });
+        let pending = Build::new(BotId::from(4), WorkerName::embedded());
+        let mut present_success = Build::new(BotId::from(5), WorkerName::embedded());
+        present_success.make_running();
+        present_success.make_finished(BuildResult::Success);
+
+        let resets = worker
+            .reconcile_builds(&[running, missing_success, failed, pending, present_success])
+            .into_reset_builds();
+
+        assert_eq!(
+            resets,
+            vec![
+                BuildKey {
+                    bot_id: BotId::from(1),
+                    worker_name: WorkerName::embedded(),
+                },
+                BuildKey {
+                    bot_id: BotId::from(2),
+                    worker_name: WorkerName::embedded(),
+                },
+            ]
+        );
+        supervisor.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn build_completions_preserve_success_and_failure_correlation() {
+        let directory = tempfile::tempdir().unwrap();
+        let build_command = script(
+            directory.path(),
+            "build.sh",
+            "case \"$1\" in *2) echo rejected >&2; exit 1;; *) exit 0;; esac",
+        );
+        let StartedWorker { worker, supervisor } = start_embedded_worker(
+            directory.path(),
+            config(format!("{build_command} {{DIR}}"), "true".to_string()),
+        )
+        .unwrap();
+
+        worker.submit(Work::Build(build_input(1))).await.unwrap();
+        worker.submit(Work::Build(build_input(2))).await.unwrap();
+
+        let Completion::Build(first) = worker.next().await.unwrap() else {
+            panic!("expected a build completion");
+        };
+        let Completion::Build(second) = worker.next().await.unwrap() else {
+            panic!("expected a build completion");
+        };
+        assert_eq!(first.bot_id, BotId::from(1));
+        assert_eq!(first.worker_name, WorkerName::embedded());
+        assert!(matches!(first.result, BuildResult::Success));
+        assert_eq!(second.bot_id, BotId::from(2));
+        assert_eq!(second.worker_name, WorkerName::embedded());
+        assert!(matches!(
+            second.result,
+            BuildResult::Failure { ref stderr } if stderr.contains("rejected")
+        ));
+        supervisor.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn match_completions_use_the_interface_and_keep_replays_distinct() {
+        let directory = tempfile::tempdir().unwrap();
+        let match_command = script(
+            directory.path(),
+            "match.sh",
+            "printf replay > \"$1\"\nprintf '%s\\n' '{\"ranks\":[0,1],\"errors\":[0,0]}'",
+        );
+        let StartedWorker { worker, supervisor } = start_embedded_worker(
+            directory.path(),
+            config(
+                "true".to_string(),
+                format!("{match_command} {{REPLAY_PATH}}"),
+            ),
+        )
+        .unwrap();
+
+        worker.submit(Work::Match(match_input(42))).await.unwrap();
+        worker.submit(Work::Match(match_input(42))).await.unwrap();
+        let Completion::Match {
+            input: first_input,
+            output: first,
+        } = worker.next().await.unwrap()
+        else {
+            panic!("expected a match completion");
+        };
+        let Completion::Match {
+            input: second_input,
+            output: second,
+        } = worker.next().await.unwrap()
+        else {
+            panic!("expected a match completion");
         };
 
-        let (first_command, first_path) = prepare_play_match_command(&config, &input).unwrap();
-        let (second_command, second_path) = prepare_play_match_command(&config, &input).unwrap();
-        let first_path = first_path.unwrap();
-        let second_path = second_path.unwrap();
+        assert_eq!(first_input.seed, 42);
+        assert_eq!(second_input.seed, 42);
+        assert_eq!(first.participants.len(), 2);
+        assert_eq!(second.participants.len(), 2);
+        assert_ne!(first.replay_path, second.replay_path);
+        supervisor.shutdown().await.unwrap();
+    }
 
-        assert_ne!(first_path, second_path);
-        assert_eq!(first_command[1], "42");
-        assert_eq!(first_command[2], first_path.to_str().unwrap());
-        assert_eq!(second_command[2], second_path.to_str().unwrap());
-        assert_eq!(first_command[3], "bot bots/1");
-        assert_eq!(first_command[4], "bot bots/2");
+    #[tokio::test]
+    async fn malformed_match_output_is_an_observable_terminal_failure() {
+        let directory = tempfile::tempdir().unwrap();
+        let match_command = script(directory.path(), "malformed-match.sh", "printf not-json");
+        let StartedWorker { worker, supervisor } =
+            start_embedded_worker(directory.path(), config("true".to_string(), match_command))
+                .unwrap();
+
+        worker.submit(Work::Match(match_input(7))).await.unwrap();
+        let failure = tokio::time::timeout(Duration::from_secs(2), supervisor.failed())
+            .await
+            .expect("worker failure should be observable");
+        assert!(failure.to_string().contains("valid JSON"));
+        assert!(matches!(
+            worker.next().await,
+            Err(WorkerUnavailable::Failed(_))
+        ));
+        assert!(supervisor.shutdown().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn saturation_waits_and_shutdown_releases_submitters() {
+        let directory = tempfile::tempdir().unwrap();
+        let match_command = script(directory.path(), "blocking-match.sh", "exec sleep 30");
+        let StartedWorker { worker, supervisor } =
+            start_embedded_worker(directory.path(), config("true".to_string(), match_command))
+                .unwrap();
+
+        for seed in 0..5 {
+            worker.submit(Work::Match(match_input(seed))).await.unwrap();
+        }
+        let blocked = worker.submit(Work::Match(match_input(5)));
+        tokio::pin!(blocked);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), &mut blocked)
+                .await
+                .is_err()
+        );
+
+        let shutdown = supervisor.shutdown();
+        let (submission_result, shutdown_result) =
+            tokio::time::timeout(Duration::from_secs(2), async {
+                tokio::join!(blocked, shutdown)
+            })
+            .await
+            .expect("shutdown should reap running work");
+        assert!(matches!(
+            submission_result,
+            Err(WorkerUnavailable::ShuttingDown)
+        ));
+        shutdown_result.unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- replace the raw worker channel topology with documented submission, completion, reconciliation, failure, and supervision capabilities
- keep matchmaking and in-flight policy in Arena while moving bounded admission and completion delivery behind the worker seam
- supervise worker tasks and child processes through terminal failure and orderly server shutdown
- replace fabricated worker channels in Arena tests with the real embedded worker and local command/filesystem stand-ins

## Verification
- `cargo test` — 78 passed
- `cargo clippy --all-targets -- -D warnings -A clippy::too-many-arguments -A clippy::needless-range-loop -A clippy::needless-return`
- launched `target/debug/cgarena run <temporary-arena>`, sent SIGINT, and observed exit code 0

Closes #14