### PR TITLE
Deepen replay artifact lifecycle ownership

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -5,6 +5,7 @@ use crate::domain::*;
 use crate::match_retrieval::MatchRetrieval;
 use crate::matchmaking;
 use crate::ranking::Ranker;
+use crate::replay_artifact::ReplayArtifacts;
 use crate::worker::{
     BuildBotInput, BuildBotOutput, BuildReconciliation, Completion, PlayMatchBot, PlayMatchInput,
     PlayMatchOutput, Work, Worker, WorkerUnavailable,
@@ -132,7 +133,7 @@ struct Arena {
     uncertainty_coefficient: f64,
     pool: SqlitePool,
     match_retrieval: MatchRetrieval,
-    arena_path: PathBuf,
+    replay_artifacts: ReplayArtifacts,
     bots: Vec<Bot>,
     builds: Vec<Build>,
     ranker: Arc<Ranker>,
@@ -154,12 +155,13 @@ impl Arena {
     ) -> Self {
         let ranker = Arc::new(ranker);
         let match_retrieval = MatchRetrieval::new(pool.clone());
+        let replay_artifacts = ReplayArtifacts::new(pool.clone(), arena_path);
         Self {
             game_config,
             uncertainty_coefficient: leaderboards_config.uncertainty_coefficient.unwrap_or(3.0),
             matchmaking_enabled: matchmaking_config.enabled_on_start.unwrap_or(true),
             matchmaking_config,
-            arena_path,
+            replay_artifacts,
             pool,
             match_retrieval: match_retrieval.clone(),
             ranker: Arc::clone(&ranker),
@@ -340,18 +342,10 @@ impl Arena {
 
     async fn cmd_delete_bot(&mut self, id: BotId) {
         // builds and participations are deleted by foreign keys; matches by the DB trigger
-        let replay_paths = db::fetch_replay_paths_for_bot(&self.pool, id)
+        self.replay_artifacts
+            .delete_bot(id)
             .await
-            .expect("Cannot fetch replay artifacts for bot");
-        db::delete_bot(&self.pool, id)
-            .await
-            .expect("Cannot delete bot from DB");
-        for replay_path in replay_paths {
-            if let Err(error) = crate::replay_artifact::remove(&self.arena_path, &replay_path).await
-            {
-                warn!("Cannot delete replay artifact: {error:#}");
-            }
-        }
+            .expect("Cannot delete bot and its replay artifacts");
         self.bots.retain(|bot| bot.id != id);
         self.builds.retain(|b| b.bot_id != id);
         self.recalculate_computed_full();
@@ -662,36 +656,27 @@ impl Arena {
     #[instrument(skip(self, input, output), level = "debug")]
     async fn process_finished_match(&mut self, input: &PlayMatchInput, output: PlayMatchOutput) {
         self.forget_scheduled_match(input);
-        let replay_path = output.replay_path.clone();
+        let PlayMatchOutput {
+            seed,
+            participants,
+            attributes,
+            replay,
+        } = output;
 
-        if output
-            .participants
+        if participants
             .iter()
             .any(|participant| self.bots.iter().all(|bot| bot.id != participant.bot_id))
         {
             warn!("Match participant was deleted while match was running, ignoring match results");
-            if let Some(replay_path) = replay_path {
-                if let Err(error) =
-                    crate::replay_artifact::remove(&self.arena_path, &replay_path).await
-                {
-                    warn!("Cannot delete ignored replay artifact: {error:#}");
-                }
-            }
             return;
         }
 
-        let attributes = output
-            .attributes
+        let attributes = attributes
             .into_iter()
             .unique_by(|attribute| (attribute.name.clone(), attribute.bot_id, attribute.turn))
             .collect();
 
-        let mut new_match = Match::new(
-            output.seed,
-            output.participants,
-            attributes,
-            output.replay_path,
-        );
+        let mut new_match = Match::new(seed, participants, attributes, None);
 
         new_match
             .attributes
@@ -700,7 +685,7 @@ impl Arena {
             name: "seed".to_string(),
             bot_id: None,
             turn: None,
-            value: MatchAttributeValue::Integer(output.seed),
+            value: MatchAttributeValue::Integer(seed),
         });
 
         new_match
@@ -750,14 +735,11 @@ impl Arena {
             });
         }
 
-        if let Err(error) = db::persist_match(&self.pool, &mut new_match).await {
-            if let Some(replay_path) = &new_match.replay_path {
-                if let Err(cleanup_error) =
-                    crate::replay_artifact::remove(&self.arena_path, replay_path).await
-                {
-                    warn!("Cannot clean unpersisted replay artifact: {cleanup_error:#}");
-                }
-            }
+        if let Err(error) = self
+            .replay_artifacts
+            .persist_match(replay, &mut new_match)
+            .await
+        {
             panic!("Cannot persist match to DB: {error:#}");
         }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -5,7 +5,7 @@ use anyhow::bail;
 use chrono::{DateTime, Utc};
 use indoc::indoc;
 use sqlx::{sqlite::SqliteConnectOptions, ConnectOptions, SqlitePool};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::time::Duration;
 use tracing::warn;
 
@@ -301,105 +301,6 @@ pub async fn create_match(pool: &SqlitePool, m: &Match) -> anyhow::Result<MatchI
     tx.commit().await?;
     Ok(match_id)
 }
-pub struct ReplayMetadata {
-    pub replay_path: Option<PathBuf>,
-    pub participant_count: u8,
-}
-
-pub async fn fetch_replay_metadata(
-    pool: &SqlitePool,
-    match_id: MatchId,
-) -> anyhow::Result<Option<ReplayMetadata>> {
-    let row = sqlx::query_as::<_, (Option<String>, u8)>(
-        "SELECT replay_path, participant_cnt FROM matches WHERE id = ?",
-    )
-    .bind::<i64>(match_id.into())
-    .fetch_optional(pool)
-    .await?;
-
-    Ok(row.map(|(replay_path, participant_count)| ReplayMetadata {
-        replay_path: replay_path.map(PathBuf::from),
-        participant_count,
-    }))
-}
-
-pub async fn fetch_replay_paths_for_bot(
-    pool: &SqlitePool,
-    bot_id: BotId,
-) -> anyhow::Result<Vec<PathBuf>> {
-    Ok(sqlx::query_scalar::<_, String>(
-        "SELECT m.replay_path
-         FROM matches m
-         INNER JOIN participations p ON p.match_id = m.id
-         WHERE p.bot_id = ? AND m.replay_path IS NOT NULL",
-    )
-    .bind::<i64>(bot_id.into())
-    .fetch_all(pool)
-    .await?
-    .into_iter()
-    .map(PathBuf::from)
-    .collect())
-}
-
-pub async fn wipe_old_matches<F: Fn(usize) -> bool>(
-    arena_path: &Path,
-    percentage: u8,
-    vacuum: bool,
-    confirm: F,
-) -> anyhow::Result<usize> {
-    let db_path = arena_path.join(DB_FILE_NAME);
-
-    let opts = SqliteConnectOptions::new()
-        .filename(db_path)
-        .journal_mode(sqlx::sqlite::SqliteJournalMode::Delete)
-        .create_if_missing(false);
-
-    let mut conn = opts.connect().await?;
-    sqlx::migrate!().run(&mut conn).await?;
-
-    let percentage = percentage.clamp(0, 100);
-
-    let mut match_ids: Vec<(i64,)> = sqlx::query_as("SELECT id FROM matches")
-        .fetch_all(&mut conn)
-        .await?;
-
-    match_ids.sort();
-
-    let amount_to_delete = (match_ids.len() as u64) * (percentage as u64) / 100;
-    if amount_to_delete == 0 {
-        println!("0 matches to delete, skipping");
-    } else {
-        if !confirm(amount_to_delete as usize) {
-            bail!("Cancelled by the user");
-        }
-
-        assert!(amount_to_delete <= match_ids.len() as u64);
-        let last_deleted_id = match_ids[amount_to_delete as usize - 1].0;
-        let replay_paths = sqlx::query_scalar::<_, String>(
-            "SELECT replay_path FROM matches WHERE id <= ? AND replay_path IS NOT NULL",
-        )
-        .bind(last_deleted_id)
-        .fetch_all(&mut conn)
-        .await?;
-
-        println!("Deleting {} old matches", amount_to_delete);
-
-        sqlx::query("DELETE FROM matches WHERE id <= $1")
-            .bind::<i64>(last_deleted_id)
-            .execute(&mut conn)
-            .await?;
-        for replay_path in replay_paths {
-            crate::replay_artifact::remove(arena_path, Path::new(&replay_path)).await?;
-        }
-    }
-
-    if vacuum {
-        println!("Vacuuming the db");
-        sqlx::query("VACUUM").execute(&mut conn).await?;
-    }
-
-    Ok(amount_to_delete as usize)
-}
 
 pub async fn persist_leaderboard(
     pool: &SqlitePool,
@@ -472,72 +373,4 @@ pub async fn fetch_leaderboards(pool: &SqlitePool) -> anyhow::Result<Vec<Leaderb
         })
         .collect();
     Ok(leaderboards)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn replay_metadata_preserves_paths_and_leaves_legacy_matches_unavailable() {
-        let pool = in_memory().await.unwrap();
-        sqlx::migrate!().run(&pool).await.unwrap();
-        let legacy_id: MatchId =
-            sqlx::query("INSERT INTO matches (seed, participant_cnt) VALUES (1, 2)")
-                .execute(&pool)
-                .await
-                .unwrap()
-                .last_insert_rowid()
-                .into();
-        let replay_path = "replays/fixture.json";
-        let replay_id: MatchId = sqlx::query(
-            "INSERT INTO matches (seed, participant_cnt, replay_path) VALUES (2, 4, ?)",
-        )
-        .bind(replay_path)
-        .execute(&pool)
-        .await
-        .unwrap()
-        .last_insert_rowid()
-        .into();
-
-        let legacy = fetch_replay_metadata(&pool, legacy_id)
-            .await
-            .unwrap()
-            .unwrap();
-        assert!(legacy.replay_path.is_none());
-        let replay = fetch_replay_metadata(&pool, replay_id)
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(replay.replay_path, Some(PathBuf::from(replay_path)));
-        assert_eq!(replay.participant_count, 4);
-    }
-
-    #[tokio::test]
-    async fn wiping_matches_removes_owned_replay_artifacts() {
-        let arena = tempfile::tempdir().unwrap();
-        let pool = connect(arena.path()).await.unwrap();
-        sqlx::migrate!().run(&pool).await.unwrap();
-        let replay_path = PathBuf::from("replays/fixture.json");
-        tokio::fs::create_dir_all(arena.path().join("replays"))
-            .await
-            .unwrap();
-        tokio::fs::write(arena.path().join(&replay_path), b"fixture")
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO matches (seed, participant_cnt, replay_path) VALUES (1, 2, ?)")
-            .bind(replay_path.to_str().unwrap())
-            .execute(&pool)
-            .await
-            .unwrap();
-        pool.close().await;
-
-        assert_eq!(
-            wipe_old_matches(arena.path(), 100, false, |_| true)
-                .await
-                .unwrap(),
-            1
-        );
-        assert!(!arena.path().join(replay_path).exists());
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,7 @@ async fn handle_cli_command(command: Commands) -> anyhow::Result<()> {
             vacuum,
         } => {
             let path = unwrap_or_current_dir(path)?;
-            db::wipe_old_matches(&path, percentage, vacuum, |cnt| {
+            replay_artifact::wipe_old_matches(&path, percentage, vacuum, |cnt| {
                 if yes {
                     true
                 } else {

--- a/src/replay_artifact.rs
+++ b/src/replay_artifact.rs
@@ -1,14 +1,319 @@
+use crate::{
+    db,
+    domain::{BotId, Match, MatchId},
+};
 use anyhow::{bail, Context};
+use sqlx::{
+    sqlite::{SqliteConnectOptions, SqlitePoolOptions},
+    SqlitePool,
+};
 use std::path::{Component, Path, PathBuf};
+use tracing::warn;
 use uuid::Uuid;
 
 const REPLAY_DIRECTORY: &str = "replays";
+const DB_FILE_NAME: &str = "cgarena.db";
 
-pub fn allocate() -> PathBuf {
-    PathBuf::from(REPLAY_DIRECTORY).join(format!("{}.json", Uuid::new_v4()))
+/// Owns replay artifacts from match persistence through lookup and deletion.
+///
+/// The lifecycle has three states:
+/// - [`ProvisionalReplay`] owns a unique path reserved for a running match command.
+/// - [`PendingReplay`] owns a non-empty file that is not yet referenced by a match row.
+/// - a persisted match row owns its replay path after [`ReplayArtifacts::persist_match`] commits.
+///
+/// Provisional and pending owners compensate by deleting their file when they are rejected,
+/// dropped, or fail to transition. Persisted artifacts are validated on lookup and are deleted
+/// before the database operation that removes their owning match.
+#[derive(Clone)]
+pub struct ReplayArtifacts {
+    pool: SqlitePool,
+    arena_path: PathBuf,
 }
 
-pub fn resolve(arena_path: &Path, replay_path: &Path) -> anyhow::Result<PathBuf> {
+impl ReplayArtifacts {
+    pub fn new(pool: SqlitePool, arena_path: PathBuf) -> Self {
+        Self { pool, arena_path }
+    }
+
+    /// Atomically transfers an optional pending artifact to a newly persisted match.
+    /// A failed database write leaves the artifact pending, so its owner removes it.
+    pub async fn persist_match(
+        &self,
+        replay: PendingReplay,
+        new_match: &mut Match,
+    ) -> anyhow::Result<()> {
+        let artifact = replay.artifact;
+        new_match.replay_path = artifact
+            .as_ref()
+            .map(|artifact| artifact.relative_path.clone());
+
+        db::persist_match(&self.pool, new_match).await?;
+        if let Some(artifact) = artifact {
+            artifact.commit();
+        }
+        Ok(())
+    }
+
+    /// Resolves a persisted artifact only after its row, path, and file are validated.
+    pub async fn lookup(&self, match_id: MatchId) -> Result<ReadableReplay, ReplayLookupError> {
+        let row = sqlx::query_as::<_, (Option<String>, u8)>(
+            "SELECT replay_path, participant_cnt FROM matches WHERE id = ?",
+        )
+        .bind::<i64>(match_id.into())
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|error| ReplayLookupError::Internal(error.to_string()))?
+        .ok_or(ReplayLookupError::MatchNotFound)?;
+
+        let relative_path = row.0.ok_or(ReplayLookupError::Unavailable)?;
+        let path = resolve(&self.arena_path, Path::new(&relative_path))
+            .map_err(|error| ReplayLookupError::InvalidArtifact(error.to_string()))?;
+        let metadata = tokio::fs::metadata(&path)
+            .await
+            .map_err(|error| ReplayLookupError::InvalidArtifact(error.to_string()))?;
+        if !metadata.is_file() || metadata.len() == 0 {
+            return Err(ReplayLookupError::InvalidArtifact(
+                "artifact is not a non-empty file".to_string(),
+            ));
+        }
+
+        Ok(ReadableReplay {
+            path,
+            participant_count: row.1,
+        })
+    }
+
+    /// Deletes every match artifact owned through a bot before deleting the bot and its matches.
+    pub async fn delete_bot(&self, bot_id: BotId) -> anyhow::Result<()> {
+        let paths = sqlx::query_scalar::<_, String>(
+            "SELECT m.replay_path
+             FROM matches m
+             INNER JOIN participations p ON p.match_id = m.id
+             WHERE p.bot_id = ? AND m.replay_path IS NOT NULL",
+        )
+        .bind::<i64>(bot_id.into())
+        .fetch_all(&self.pool)
+        .await?;
+
+        self.remove_all(paths).await?;
+        db::delete_bot(&self.pool, bot_id).await
+    }
+
+    async fn delete_old_matches<F: Fn(usize) -> bool>(
+        &self,
+        percentage: u8,
+        vacuum: bool,
+        confirm: F,
+    ) -> anyhow::Result<usize> {
+        let percentage = percentage.clamp(0, 100);
+        let mut match_ids: Vec<(i64,)> = sqlx::query_as("SELECT id FROM matches")
+            .fetch_all(&self.pool)
+            .await?;
+        match_ids.sort();
+
+        let amount_to_delete = match_ids.len() * usize::from(percentage) / 100;
+        if amount_to_delete == 0 {
+            println!("0 matches to delete, skipping");
+        } else {
+            if !confirm(amount_to_delete) {
+                bail!("Cancelled by the user");
+            }
+
+            let last_deleted_id = match_ids[amount_to_delete - 1].0;
+            let paths = sqlx::query_scalar::<_, String>(
+                "SELECT replay_path FROM matches WHERE id <= ? AND replay_path IS NOT NULL",
+            )
+            .bind(last_deleted_id)
+            .fetch_all(&self.pool)
+            .await?;
+
+            println!("Deleting {amount_to_delete} old matches");
+            self.remove_all(paths).await?;
+            sqlx::query("DELETE FROM matches WHERE id <= ?")
+                .bind(last_deleted_id)
+                .execute(&self.pool)
+                .await?;
+        }
+
+        if vacuum {
+            println!("Vacuuming the db");
+            sqlx::query("VACUUM").execute(&self.pool).await?;
+        }
+
+        Ok(amount_to_delete)
+    }
+
+    async fn remove_all(&self, paths: Vec<String>) -> anyhow::Result<()> {
+        for path in paths {
+            remove(&self.arena_path, Path::new(&path)).await?;
+        }
+        Ok(())
+    }
+}
+
+/// Owns the unique replay path offered to one running match command.
+#[derive(Debug)]
+pub struct ProvisionalReplay {
+    artifact: Option<OwnedReplay>,
+}
+
+impl ProvisionalReplay {
+    pub async fn create(arena_path: &Path) -> anyhow::Result<Self> {
+        let relative_path =
+            PathBuf::from(REPLAY_DIRECTORY).join(format!("{}.json", Uuid::new_v4()));
+        let absolute_path = resolve(arena_path, &relative_path)?;
+        let parent = absolute_path
+            .parent()
+            .context("replay artifact must have a parent directory")?;
+        tokio::fs::create_dir_all(parent)
+            .await
+            .context("cannot create replay directory")?;
+
+        Ok(Self {
+            artifact: Some(OwnedReplay::new(arena_path, relative_path)?),
+        })
+    }
+
+    pub fn command_path(&self) -> &Path {
+        &self
+            .artifact
+            .as_ref()
+            .expect("provisional replay ownership cannot be reused")
+            .relative_path
+    }
+
+    /// Accepts only a non-empty regular file and transfers ownership to the pending state.
+    pub async fn finish(mut self) -> anyhow::Result<PendingReplay> {
+        let artifact = self
+            .artifact
+            .as_ref()
+            .expect("provisional replay ownership cannot be reused");
+        match tokio::fs::metadata(&artifact.absolute_path).await {
+            Ok(metadata) if metadata.is_file() && metadata.len() > 0 => Ok(PendingReplay {
+                artifact: self.artifact.take(),
+            }),
+            Ok(_) => {
+                warn!("match command produced an empty replay artifact");
+                self.remove().await?;
+                Ok(PendingReplay::default())
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                warn!("match command produced no replay artifact");
+                self.remove().await?;
+                Ok(PendingReplay::default())
+            }
+            Err(error) => Err(error).context("cannot inspect replay artifact"),
+        }
+    }
+
+    async fn remove(&mut self) -> anyhow::Result<()> {
+        if let Some(artifact) = self.artifact.take() {
+            artifact.remove().await?;
+        }
+        Ok(())
+    }
+}
+
+/// Owns a produced artifact until match persistence accepts it.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct PendingReplay {
+    artifact: Option<OwnedReplay>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct OwnedReplay {
+    relative_path: PathBuf,
+    absolute_path: PathBuf,
+    remove_on_drop: bool,
+}
+
+impl OwnedReplay {
+    fn new(arena_path: &Path, relative_path: PathBuf) -> anyhow::Result<Self> {
+        let absolute_path = resolve(arena_path, &relative_path)?;
+        Ok(Self {
+            relative_path,
+            absolute_path,
+            remove_on_drop: true,
+        })
+    }
+
+    async fn remove(mut self) -> anyhow::Result<()> {
+        remove_absolute(&self.absolute_path).await?;
+        self.remove_on_drop = false;
+        Ok(())
+    }
+
+    fn commit(mut self) {
+        self.remove_on_drop = false;
+    }
+}
+
+impl Drop for OwnedReplay {
+    fn drop(&mut self) {
+        if !self.remove_on_drop {
+            return;
+        }
+
+        match std::fs::remove_file(&self.absolute_path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => warn!(
+                "cannot compensate replay artifact {}: {error}",
+                self.absolute_path.display()
+            ),
+        }
+    }
+}
+
+pub struct ReadableReplay {
+    path: PathBuf,
+    participant_count: u8,
+}
+
+impl ReadableReplay {
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn participant_count(&self) -> u8 {
+        self.participant_count
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ReplayLookupError {
+    #[error("match not found")]
+    MatchNotFound,
+    #[error("this match has no replay artifact")]
+    Unavailable,
+    #[error("replay artifact is missing or invalid: {0}")]
+    InvalidArtifact(String),
+    #[error("replay artifact lookup failed: {0}")]
+    Internal(String),
+}
+
+pub async fn wipe_old_matches<F: Fn(usize) -> bool>(
+    arena_path: &Path,
+    percentage: u8,
+    vacuum: bool,
+    confirm: F,
+) -> anyhow::Result<usize> {
+    let options = SqliteConnectOptions::new()
+        .filename(arena_path.join(DB_FILE_NAME))
+        .journal_mode(sqlx::sqlite::SqliteJournalMode::Delete)
+        .create_if_missing(false);
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(options)
+        .await?;
+    sqlx::migrate!().run(&pool).await?;
+
+    ReplayArtifacts::new(pool, arena_path.to_owned())
+        .delete_old_matches(percentage, vacuum, confirm)
+        .await
+}
+
+fn resolve(arena_path: &Path, replay_path: &Path) -> anyhow::Result<PathBuf> {
     if replay_path.is_absolute() {
         bail!("replay path must be relative to the arena");
     }
@@ -23,11 +328,233 @@ pub fn resolve(arena_path: &Path, replay_path: &Path) -> anyhow::Result<PathBuf>
     Ok(arena_path.join(replay_path))
 }
 
-pub async fn remove(arena_path: &Path, replay_path: &Path) -> anyhow::Result<()> {
+async fn remove(arena_path: &Path, replay_path: &Path) -> anyhow::Result<()> {
     let path = resolve(arena_path, replay_path)?;
-    match tokio::fs::remove_file(&path).await {
+    remove_absolute(&path).await
+}
+
+async fn remove_absolute(path: &Path) -> anyhow::Result<()> {
+    match tokio::fs::remove_file(path).await {
         Ok(()) => Ok(()),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(error) => Err(error).with_context(|| format!("cannot delete {}", path.display())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{Match, Participant};
+    use tempfile::TempDir;
+
+    async fn fixture() -> (TempDir, ReplayArtifacts) {
+        let arena = tempfile::tempdir().unwrap();
+        let pool = db::in_memory().await.unwrap();
+        sqlx::migrate!().run(&pool).await.unwrap();
+        let artifacts = ReplayArtifacts::new(pool, arena.path().to_owned());
+        (arena, artifacts)
+    }
+
+    async fn insert_bot(artifacts: &ReplayArtifacts, name: &str) -> BotId {
+        sqlx::query(
+            "INSERT INTO bots (name, source_code, language, created_at) VALUES (?, '', 'rust', 0)",
+        )
+        .bind(name)
+        .execute(&artifacts.pool)
+        .await
+        .unwrap()
+        .last_insert_rowid()
+        .into()
+    }
+
+    fn new_match(bot_ids: &[BotId], replay_path: Option<PathBuf>) -> Match {
+        Match::new(
+            7,
+            bot_ids
+                .iter()
+                .enumerate()
+                .map(|(rank, bot_id)| Participant {
+                    bot_id: *bot_id,
+                    rank: rank as u8,
+                    error: false,
+                })
+                .collect(),
+            vec![],
+            replay_path,
+        )
+    }
+
+    async fn produced_replay(arena: &TempDir, contents: &[u8]) -> (PendingReplay, PathBuf) {
+        let provisional = ProvisionalReplay::create(arena.path()).await.unwrap();
+        let path = provisional.command_path().to_owned();
+        tokio::fs::write(arena.path().join(&path), contents)
+            .await
+            .unwrap();
+        (provisional.finish().await.unwrap(), path)
+    }
+
+    #[tokio::test]
+    async fn successful_persistence_transfers_ownership_and_lookup_validates_the_artifact() {
+        let (arena, artifacts) = fixture().await;
+        let bot_1 = insert_bot(&artifacts, "one").await;
+        let bot_2 = insert_bot(&artifacts, "two").await;
+        let (pending, relative_path) = produced_replay(&arena, b"replay").await;
+        let mut new_match = new_match(&[bot_1, bot_2], None);
+
+        artifacts
+            .persist_match(pending, &mut new_match)
+            .await
+            .unwrap();
+        let readable = artifacts.lookup(new_match.id).await.unwrap();
+
+        assert_eq!(readable.path(), arena.path().join(&relative_path));
+        assert_eq!(readable.participant_count(), 2);
+        assert!(readable.path().exists());
+    }
+
+    #[tokio::test]
+    async fn rejected_output_or_deleted_participant_discards_the_pending_artifact() {
+        let (arena, _artifacts) = fixture().await;
+        let (pending, relative_path) = produced_replay(&arena, b"replay").await;
+
+        drop(pending);
+
+        assert!(!arena.path().join(relative_path).exists());
+    }
+
+    #[tokio::test]
+    async fn persistence_failure_compensates_the_pending_artifact() {
+        let (arena, artifacts) = fixture().await;
+        let (pending, relative_path) = produced_replay(&arena, b"replay").await;
+        let mut new_match = new_match(&[BotId::from(404)], None);
+
+        assert!(artifacts
+            .persist_match(pending, &mut new_match)
+            .await
+            .is_err());
+        assert!(!arena.path().join(relative_path).exists());
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM matches")
+            .fetch_one(&artifacts.pool)
+            .await
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn bot_deletion_removes_artifacts_owned_by_deleted_matches() {
+        let (arena, artifacts) = fixture().await;
+        let bot_1 = insert_bot(&artifacts, "one").await;
+        let bot_2 = insert_bot(&artifacts, "two").await;
+        let (pending, relative_path) = produced_replay(&arena, b"replay").await;
+        let mut new_match = new_match(&[bot_1, bot_2], None);
+        artifacts
+            .persist_match(pending, &mut new_match)
+            .await
+            .unwrap();
+
+        artifacts.delete_bot(bot_1).await.unwrap();
+
+        assert!(!arena.path().join(relative_path).exists());
+        assert!(matches!(
+            artifacts.lookup(new_match.id).await,
+            Err(ReplayLookupError::MatchNotFound)
+        ));
+    }
+
+    #[tokio::test]
+    async fn retention_deletes_only_artifacts_owned_by_removed_matches() {
+        let (arena, artifacts) = fixture().await;
+        let bot_1 = insert_bot(&artifacts, "one").await;
+        let bot_2 = insert_bot(&artifacts, "two").await;
+        let (old_pending, old_path) = produced_replay(&arena, b"old").await;
+        let mut old_match = new_match(&[bot_1, bot_2], None);
+        artifacts
+            .persist_match(old_pending, &mut old_match)
+            .await
+            .unwrap();
+        let (new_pending, new_path) = produced_replay(&arena, b"new").await;
+        let mut new_match = new_match(&[bot_1, bot_2], None);
+        artifacts
+            .persist_match(new_pending, &mut new_match)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            artifacts
+                .delete_old_matches(50, false, |_| true)
+                .await
+                .unwrap(),
+            1
+        );
+
+        assert!(!arena.path().join(old_path).exists());
+        assert!(arena.path().join(new_path).exists());
+        assert!(matches!(
+            artifacts.lookup(old_match.id).await,
+            Err(ReplayLookupError::MatchNotFound)
+        ));
+        artifacts.lookup(new_match.id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn missing_empty_and_legacy_artifacts_have_distinct_lookup_results() {
+        let (arena, artifacts) = fixture().await;
+        let missing_id: MatchId = sqlx::query(
+            "INSERT INTO matches (seed, participant_cnt, replay_path) VALUES (1, 2, 'replays/missing.json')",
+        )
+        .execute(&artifacts.pool)
+        .await
+        .unwrap()
+        .last_insert_rowid()
+        .into();
+        tokio::fs::create_dir_all(arena.path().join(REPLAY_DIRECTORY))
+            .await
+            .unwrap();
+        tokio::fs::write(arena.path().join("replays/empty.json"), b"")
+            .await
+            .unwrap();
+        let empty_id: MatchId = sqlx::query(
+            "INSERT INTO matches (seed, participant_cnt, replay_path) VALUES (2, 2, 'replays/empty.json')",
+        )
+        .execute(&artifacts.pool)
+        .await
+        .unwrap()
+        .last_insert_rowid()
+        .into();
+        let legacy_id: MatchId =
+            sqlx::query("INSERT INTO matches (seed, participant_cnt) VALUES (3, 2)")
+                .execute(&artifacts.pool)
+                .await
+                .unwrap()
+                .last_insert_rowid()
+                .into();
+
+        assert!(matches!(
+            artifacts.lookup(missing_id).await,
+            Err(ReplayLookupError::InvalidArtifact(_))
+        ));
+        assert!(matches!(
+            artifacts.lookup(empty_id).await,
+            Err(ReplayLookupError::InvalidArtifact(_))
+        ));
+        assert!(matches!(
+            artifacts.lookup(legacy_id).await,
+            Err(ReplayLookupError::Unavailable)
+        ));
+    }
+
+    #[tokio::test]
+    async fn empty_provisional_artifact_is_removed_before_becoming_unavailable() {
+        let (arena, _artifacts) = fixture().await;
+        let provisional = ProvisionalReplay::create(arena.path()).await.unwrap();
+        let relative_path = provisional.command_path().to_owned();
+        tokio::fs::write(arena.path().join(&relative_path), b"")
+            .await
+            .unwrap();
+
+        let pending = provisional.finish().await.unwrap();
+
+        assert_eq!(pending, PendingReplay::default());
+        assert!(!arena.path().join(relative_path).exists());
     }
 }

--- a/src/replay_viewer.rs
+++ b/src/replay_viewer.rs
@@ -17,7 +17,12 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
-use crate::{db, domain::MatchId, replay_artifact};
+#[cfg(test)]
+use crate::db;
+use crate::{
+    domain::MatchId,
+    replay_artifact::{ReplayArtifacts, ReplayLookupError},
+};
 
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
 const SESSION_IDLE_LIFETIME: Duration = Duration::from_secs(15 * 60);
@@ -30,7 +35,7 @@ pub struct ReplayViewer {
 }
 
 struct ReplayViewerInner {
-    pool: sqlx::SqlitePool,
+    replay_artifacts: ReplayArtifacts,
     arena_path: PathBuf,
     command: String,
     sessions: Mutex<HashMap<String, ReplaySession>>,
@@ -76,6 +81,17 @@ pub enum ReplayError {
     Internal(String),
 }
 
+impl From<ReplayLookupError> for ReplayError {
+    fn from(error: ReplayLookupError) -> Self {
+        match error {
+            ReplayLookupError::MatchNotFound => Self::MatchNotFound,
+            ReplayLookupError::Unavailable => Self::Unavailable,
+            ReplayLookupError::InvalidArtifact(message) => Self::InvalidArtifact(message),
+            ReplayLookupError::Internal(message) => Self::Internal(message),
+        }
+    }
+}
+
 impl ReplayViewer {
     pub fn new(
         pool: sqlx::SqlitePool,
@@ -101,9 +117,10 @@ impl ReplayViewer {
         startup_timeout: Duration,
         idle_lifetime: Duration,
     ) -> Self {
+        let replay_artifacts = ReplayArtifacts::new(pool, arena_path.clone());
         Self {
             inner: Arc::new(ReplayViewerInner {
-                pool,
+                replay_artifacts,
                 arena_path,
                 command,
                 sessions: Mutex::new(HashMap::new()),
@@ -114,21 +131,7 @@ impl ReplayViewer {
     }
 
     pub async fn watch(&self, match_id: MatchId) -> Result<StartedReplay, ReplayError> {
-        let metadata = db::fetch_replay_metadata(&self.inner.pool, match_id)
-            .await
-            .map_err(|error| ReplayError::Internal(error.to_string()))?
-            .ok_or(ReplayError::MatchNotFound)?;
-        let replay_path = metadata.replay_path.ok_or(ReplayError::Unavailable)?;
-        let artifact_path = replay_artifact::resolve(&self.inner.arena_path, &replay_path)
-            .map_err(|error| ReplayError::InvalidArtifact(error.to_string()))?;
-        let artifact_metadata = fs::metadata(&artifact_path)
-            .await
-            .map_err(|error| ReplayError::InvalidArtifact(error.to_string()))?;
-        if !artifact_metadata.is_file() || artifact_metadata.len() == 0 {
-            return Err(ReplayError::InvalidArtifact(
-                "artifact is not a non-empty file".to_string(),
-            ));
-        }
+        let artifact = self.inner.replay_artifacts.lookup(match_id).await?;
 
         let session_id = Uuid::new_v4().to_string();
         let session_directory = self
@@ -142,9 +145,9 @@ impl ReplayViewer {
 
         let result = self
             .generate_bundle(
-                &artifact_path,
+                artifact.path(),
                 &session_directory,
-                metadata.participant_count,
+                artifact.participant_count(),
             )
             .await;
         if let Err(error) = result {
@@ -384,22 +387,25 @@ async fn read_stderr(mut stderr: tokio::process::ChildStderr) -> std::io::Result
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
+    use crate::{
+        domain::{BotId, Match, Participant},
+        replay_artifact::ProvisionalReplay,
+    };
     use std::os::unix::fs::PermissionsExt;
     use tempfile::TempDir;
 
     async fn fixture(
         script_body: &str,
         startup_timeout: Duration,
-    ) -> (TempDir, ReplayViewer, MatchId) {
+    ) -> (TempDir, ReplayViewer, MatchId, PathBuf) {
         let temporary_directory = tempfile::tempdir().unwrap();
         let arena_path = temporary_directory.path().join("arena with spaces");
-        fs::create_dir_all(arena_path.join("replays"))
+        let provisional = ProvisionalReplay::create(&arena_path).await.unwrap();
+        let artifact_path = arena_path.join(provisional.command_path());
+        fs::write(&artifact_path, b"{\"agents\":[{},{}]}")
             .await
             .unwrap();
-        let artifact_path = PathBuf::from("replays/fixture.json");
-        fs::write(arena_path.join(&artifact_path), b"{\"agents\":[{},{}]}")
-            .await
-            .unwrap();
+        let pending = provisional.finish().await.unwrap();
 
         let launcher_path = arena_path.join("launcher with spaces.sh");
         fs::write(
@@ -414,15 +420,37 @@ mod tests {
 
         let pool = db::connect(&arena_path).await.unwrap();
         sqlx::migrate!().run(&pool).await.unwrap();
-        let match_id: MatchId = sqlx::query(
-            "INSERT INTO matches (seed, participant_cnt, replay_path) VALUES (7, 2, ?)",
-        )
-        .bind(artifact_path.to_str().unwrap())
-        .execute(&pool)
-        .await
-        .unwrap()
-        .last_insert_rowid()
-        .into();
+        let mut bot_ids = Vec::new();
+        for name in ["one", "two"] {
+            let bot_id: BotId = sqlx::query(
+                "INSERT INTO bots (name, source_code, language, created_at) VALUES (?, '', 'rust', 0)",
+            )
+            .bind(name)
+            .execute(&pool)
+            .await
+            .unwrap()
+            .last_insert_rowid()
+            .into();
+            bot_ids.push(bot_id);
+        }
+        let mut replay_match = Match::new(
+            7,
+            bot_ids
+                .into_iter()
+                .enumerate()
+                .map(|(rank, bot_id)| Participant {
+                    bot_id,
+                    rank: rank as u8,
+                    error: false,
+                })
+                .collect(),
+            vec![],
+            None,
+        );
+        ReplayArtifacts::new(pool.clone(), arena_path.clone())
+            .persist_match(pending, &mut replay_match)
+            .await
+            .unwrap();
         let command = format!(
             "\"{}\" {{REPLAY_PATH}} {{REPLAY_DIR}} {{PORT}} {{PLAYER_COUNT}}",
             launcher_path.display()
@@ -434,12 +462,12 @@ mod tests {
             startup_timeout,
             Duration::from_secs(60),
         );
-        (temporary_directory, viewer, match_id)
+        (temporary_directory, viewer, replay_match.id, artifact_path)
     }
 
     #[tokio::test]
     async fn sessions_are_isolated_and_serve_static_assets() {
-        let (_temporary_directory, viewer, match_id) = fixture(
+        let (_temporary_directory, viewer, match_id, _artifact_path) = fixture(
             "mkdir -p \"$2\"\nprintf '<html>fixture replay</html>' > \"$2/test.html\"",
             Duration::from_secs(2),
         )
@@ -468,7 +496,7 @@ mod tests {
 
     #[tokio::test]
     async fn startup_timeout_kills_the_launcher() {
-        let (_temporary_directory, viewer, match_id) =
+        let (_temporary_directory, viewer, match_id, _artifact_path) =
             fixture("sleep 5", Duration::from_millis(50)).await;
 
         let started = Instant::now();
@@ -481,7 +509,7 @@ mod tests {
 
     #[tokio::test]
     async fn launcher_failure_returns_stderr() {
-        let (_temporary_directory, viewer, match_id) = fixture(
+        let (_temporary_directory, viewer, match_id, _artifact_path) = fixture(
             "echo actionable failure >&2\nexit 7",
             Duration::from_secs(2),
         )
@@ -496,7 +524,7 @@ mod tests {
 
     #[tokio::test]
     async fn missing_match_and_artifact_are_normal_errors() {
-        let (_temporary_directory, viewer, match_id) = fixture(
+        let (_temporary_directory, viewer, match_id, artifact_path) = fixture(
             "mkdir -p \"$2\"\nprintf ok > \"$2/test.html\"",
             Duration::from_secs(2),
         )
@@ -506,9 +534,7 @@ mod tests {
             viewer.watch(MatchId::from(i64::from(match_id) + 1)).await,
             Err(ReplayError::MatchNotFound)
         ));
-        replay_artifact::remove(&viewer.inner.arena_path, Path::new("replays/fixture.json"))
-            .await
-            .unwrap();
+        fs::remove_file(artifact_path).await.unwrap();
         assert!(matches!(
             viewer.watch(match_id).await,
             Err(ReplayError::InvalidArtifact(_))

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -3,6 +3,7 @@ use crate::domain::{
     BotId, Build, BuildResult, Language, MatchAttribute, MatchAttributeValue, Participant,
     SourceCode, WorkerName,
 };
+use crate::replay_artifact::{PendingReplay, ProvisionalReplay};
 use anyhow::{bail, Context};
 use itertools::Itertools;
 use serde::Deserialize;
@@ -509,11 +510,12 @@ async fn execute_match(
     if cancellation_token.is_cancelled() {
         return Ok(None);
     }
-    let (command_parts, replay_path) =
-        prepare_play_match_command(&config, &input).map_err(WorkerFailure::new)?;
+    let (command_parts, replay) = prepare_play_match_command(&config, &input, &worker_path)
+        .await
+        .map_err(WorkerFailure::new)?;
     let output = spawn_play_match_command(
         command_parts,
-        replay_path,
+        replay,
         worker_path,
         &input,
         &cancellation_token,
@@ -679,10 +681,11 @@ async fn run_command(
     }))
 }
 
-fn prepare_play_match_command(
+async fn prepare_play_match_command(
     config: &EmbeddedWorkerConfig,
     input: &PlayMatchInput,
-) -> anyhow::Result<(Vec<String>, Option<PathBuf>)> {
+    worker_path: &Path,
+) -> anyhow::Result<(Vec<String>, Option<ProvisionalReplay>)> {
     let run_commands = input
         .bots
         .iter()
@@ -705,21 +708,17 @@ fn prepare_play_match_command(
         bail!("cmd_play_match must not be blank");
     }
 
-    let replay_path = template
-        .iter()
-        .any(|part| part == "{REPLAY_PATH}")
-        .then(crate::replay_artifact::allocate);
-    let replay_path_value = replay_path
+    let replay = if template.iter().any(|part| part == "{REPLAY_PATH}") {
+        Some(ProvisionalReplay::create(worker_path).await?)
+    } else {
+        None
+    };
+    let replay_path_value = replay
         .as_ref()
-        .and_then(|path| path.to_str())
+        .map(ProvisionalReplay::command_path)
+        .and_then(Path::to_str)
         .context("replay path must be UTF-8")
-        .or_else(|error| {
-            if replay_path.is_none() {
-                Ok("")
-            } else {
-                Err(error)
-            }
-        })?;
+        .or_else(|error| if replay.is_none() { Ok("") } else { Err(error) })?;
     let seed = input.seed.to_string();
     let mut command_parts = Vec::new();
 
@@ -745,137 +744,101 @@ fn prepare_play_match_command(
         }
     }
 
-    Ok((command_parts, replay_path))
+    Ok((command_parts, replay))
 }
 
 async fn spawn_play_match_command(
     command_parts: Vec<String>,
-    replay_path: Option<PathBuf>,
+    replay: Option<ProvisionalReplay>,
     worker_path: PathBuf,
     input: &PlayMatchInput,
     cancellation_token: &CancellationToken,
 ) -> anyhow::Result<Option<PlayMatchOutput>> {
-    let absolute_replay_path = replay_path
-        .as_ref()
-        .map(|path| crate::replay_artifact::resolve(&worker_path, path))
-        .transpose()?;
-    if let Some(parent) = absolute_replay_path.as_ref().and_then(|path| path.parent()) {
-        tokio::fs::create_dir_all(parent)
-            .await
-            .context("cannot create replay directory")?;
+    let Some(cmd_output) = run_command(command_parts, &worker_path, cancellation_token).await?
+    else {
+        return Ok(None);
+    };
+
+    let result = if cmd_output.status.success() {
+        let stdout = String::from_utf8(cmd_output.stdout).context("stdout is not valid UTF-8")?;
+        serde_json::from_str::<CmdPlayMatchStdout>(&stdout)
+            .context("play match output should be valid JSON")?
+    } else {
+        bail!(
+            "Error while running match: {}",
+            String::from_utf8(cmd_output.stderr).context("stderr is not valid UTF-8")?
+        );
+    };
+
+    let bot_count = input.bots.len();
+    if result.ranks.len() != bot_count {
+        bail!(
+            "play match output has {} ranks for {bot_count} bots",
+            result.ranks.len()
+        );
+    }
+    if result.errors.len() != bot_count {
+        bail!(
+            "play match output has {} errors for {bot_count} bots",
+            result.errors.len()
+        );
+    }
+    if !result.scores.is_empty() && result.scores.len() != bot_count {
+        bail!(
+            "play match output has {} scores for {bot_count} bots",
+            result.scores.len()
+        );
+    }
+    if let Some(player) = result
+        .attributes
+        .iter()
+        .filter_map(|attribute| attribute.player)
+        .find(|player| *player >= bot_count)
+    {
+        bail!("play match output references missing player {player}");
     }
 
-    let result = async {
-        let Some(cmd_output) = run_command(command_parts, &worker_path, cancellation_token).await?
-        else {
-            return Ok(None);
-        };
+    let replay = match replay {
+        Some(replay) => replay.finish().await?,
+        None => PendingReplay::default(),
+    };
 
-        let result = if cmd_output.status.success() {
-            let stdout =
-                String::from_utf8(cmd_output.stdout).context("stdout is not valid UTF-8")?;
-            serde_json::from_str::<CmdPlayMatchStdout>(&stdout)
-                .context("play match output should be valid JSON")?
-        } else {
-            bail!(
-                "Error while running match: {}",
-                String::from_utf8(cmd_output.stderr).context("stderr is not valid UTF-8")?
-            );
-        };
-
-        let bot_count = input.bots.len();
-        if result.ranks.len() != bot_count {
-            bail!(
-                "play match output has {} ranks for {bot_count} bots",
-                result.ranks.len()
-            );
-        }
-        if result.errors.len() != bot_count {
-            bail!(
-                "play match output has {} errors for {bot_count} bots",
-                result.errors.len()
-            );
-        }
-        if !result.scores.is_empty() && result.scores.len() != bot_count {
-            bail!(
-                "play match output has {} scores for {bot_count} bots",
-                result.scores.len()
-            );
-        }
-        if let Some(player) = result
-            .attributes
+    Ok(Some(PlayMatchOutput {
+        seed: input.seed,
+        participants: input
+            .bots
             .iter()
-            .filter_map(|attribute| attribute.player)
-            .find(|player| *player >= bot_count)
-        {
-            bail!("play match output references missing player {player}");
-        }
-
-        let persisted_replay_path = if let Some(path) = &absolute_replay_path {
-            match tokio::fs::metadata(path).await {
-                Ok(metadata) if metadata.is_file() && metadata.len() > 0 => replay_path.clone(),
-                Ok(_) => {
-                    tracing::warn!("match command produced an empty replay artifact");
-                    None
-                }
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                    tracing::warn!("match command produced no replay artifact");
-                    None
-                }
-                Err(error) => return Err(error).context("cannot inspect replay artifact"),
-            }
-        } else {
-            None
-        };
-
-        Ok(Some(PlayMatchOutput {
-            seed: input.seed,
-            participants: input
-                .bots
-                .iter()
-                .zip(result.ranks)
-                .zip(result.errors)
-                .map(|((bot, rank), error)| Participant {
-                    bot_id: bot.bot_id,
-                    rank,
-                    error: error == 1,
-                })
-                .collect(),
-            attributes: result
-                .attributes
-                .into_iter()
-                .map(|attribute| to_match_attribute(input, attribute))
-                .chain(if result.scores.is_empty() {
-                    vec![].into_iter()
-                } else {
-                    input
-                        .bots
-                        .iter()
-                        .zip(result.scores)
-                        .map(|(bot, score)| MatchAttribute {
-                            name: "score".to_string(),
-                            bot_id: Some(bot.bot_id),
-                            turn: None,
-                            value: MatchAttributeValue::Integer(score as _),
-                        })
-                        .collect_vec()
-                        .into_iter()
-                })
-                .collect(),
-            replay_path: persisted_replay_path,
-        }))
-    }
-    .await;
-
-    if !matches!(&result, Ok(Some(_))) {
-        if let Some(path) = replay_path {
-            if let Err(error) = crate::replay_artifact::remove(&worker_path, &path).await {
-                tracing::warn!("cannot clean failed replay artifact: {error:#}");
-            }
-        }
-    }
-
-    result
+            .zip(result.ranks)
+            .zip(result.errors)
+            .map(|((bot, rank), error)| Participant {
+                bot_id: bot.bot_id,
+                rank,
+                error: error == 1,
+            })
+            .collect(),
+        attributes: result
+            .attributes
+            .into_iter()
+            .map(|attribute| to_match_attribute(input, attribute))
+            .chain(if result.scores.is_empty() {
+                vec![].into_iter()
+            } else {
+                input
+                    .bots
+                    .iter()
+                    .zip(result.scores)
+                    .map(|(bot, score)| MatchAttribute {
+                        name: "score".to_string(),
+                        bot_id: Some(bot.bot_id),
+                        turn: None,
+                        value: MatchAttributeValue::Integer(score as _),
+                    })
+                    .collect_vec()
+                    .into_iter()
+            })
+            .collect(),
+        replay,
+    }))
 }
 
 #[derive(Clone)]
@@ -908,7 +871,7 @@ pub struct PlayMatchOutput {
     pub seed: i64,
     pub participants: Vec<Participant>,
     pub attributes: Vec<MatchAttribute>,
-    pub replay_path: Option<PathBuf>,
+    pub replay: PendingReplay,
 }
 
 #[derive(Deserialize)]
@@ -1106,17 +1069,26 @@ mod tests {
         assert_eq!(second_input.seed, 42);
         assert_eq!(first.participants.len(), 2);
         assert_eq!(second.participants.len(), 2);
-        assert_ne!(first.replay_path, second.replay_path);
+        assert_ne!(first.replay, second.replay);
         supervisor.shutdown().await.unwrap();
     }
 
     #[tokio::test]
     async fn malformed_match_output_is_an_observable_terminal_failure() {
         let directory = tempfile::tempdir().unwrap();
-        let match_command = script(directory.path(), "malformed-match.sh", "printf not-json");
-        let StartedWorker { worker, supervisor } =
-            start_embedded_worker(directory.path(), config("true".to_string(), match_command))
-                .unwrap();
+        let match_command = script(
+            directory.path(),
+            "malformed-match.sh",
+            "printf replay > \"$1\"\nprintf not-json",
+        );
+        let StartedWorker { worker, supervisor } = start_embedded_worker(
+            directory.path(),
+            config(
+                "true".to_string(),
+                format!("{match_command} {{REPLAY_PATH}}"),
+            ),
+        )
+        .unwrap();
 
         worker.submit(Work::Match(match_input(7))).await.unwrap();
         let failure = tokio::time::timeout(Duration::from_secs(2), supervisor.failed())
@@ -1128,6 +1100,12 @@ mod tests {
             Err(WorkerUnavailable::Failed(_))
         ));
         assert!(supervisor.shutdown().await.is_err());
+        assert_eq!(
+            fs::read_dir(directory.path().join("replays"))
+                .unwrap()
+                .count(),
+            0
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- model provisional, pending, readable, and persisted replay ownership in `replay_artifact`
- centralize persistence compensation, validated lookup, bot deletion, and retention deletion behind the module interface
- migrate Worker, Arena, ReplayViewer, and the retention command away from raw path choreography
- replace database choreography tests with lifecycle-interface coverage, including persistence/viewing, rejection, failure, deletion, retention, and missing/empty artifacts

## Verification
- `cargo test` (83 passed)
- `cargo clippy --all-targets -- -A clippy::too-many-arguments -A clippy::needless-range-loop -A clippy::needless-return -D warnings`
- `git diff --check`

Closes #15