### PR TITLE
Deepen UI match browsing behind one seam

### DIFF
--- a/cg-arena-ui/package-lock.json
+++ b/cg-arena-ui/package-lock.json
@@ -27,6 +27,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@testing-library/react": "^16.3.3",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@types/react-syntax-highlighter": "^15.5.13",
@@ -35,9 +36,64 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.5",
         "globals": "^17.11.0",
+        "jsdom": "^30.0.1",
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.68.0",
-        "vite": "^8.2.2"
+        "vite": "^8.2.2",
+        "vitest": "^5.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -309,6 +365,159 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.2.tgz",
+      "integrity": "sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.12.tgz",
+      "integrity": "sha512-3vLQK+dXxhBMR2Wx99PTCifE+vHtW2ndZWyla8yK813ev6oGhyn8Lja8jCyGAWTJ+LEYZK7EVtJxrDj8ztevJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
@@ -435,6 +644,24 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -1703,6 +1930,74 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.3.tgz",
+      "integrity": "sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -1764,6 +2059,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
@@ -2121,6 +2423,54 @@
         "vite": "^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@vitest/mocker": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-5.0.0.tgz",
+      "integrity": "sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.31",
+        "@vitest/spy": "5.0.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^1.2.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-5.0.0.tgz",
+      "integrity": "sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
@@ -2161,6 +2511,31 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -2171,6 +2546,27 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/balanced-match": {
@@ -2194,6 +2590,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/bootstrap": {
@@ -2292,6 +2698,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -2373,6 +2789,20 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/csstype": {
@@ -2502,6 +2932,35 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2519,6 +2978,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -2564,6 +3030,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
@@ -2593,6 +3067,26 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-toolkit": {
       "version": "1.52.0",
@@ -2804,6 +3298,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2819,6 +3323,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3048,6 +3562,19 @@
       "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==",
       "license": "CC0-1.0"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3163,6 +3690,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isbot": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.2.2.tgz",
@@ -3208,6 +3742,57 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -3593,6 +4178,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3601,6 +4197,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/minimatch": {
       "version": "10.2.6",
@@ -3667,6 +4270,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/optionator": {
@@ -3744,6 +4361,19 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3819,6 +4449,30 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
@@ -4121,6 +4775,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/reselect": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
@@ -4158,6 +4822,19 @@
         "@rolldown/binding-openharmony-arm64": "1.2.6",
         "@rolldown/binding-win32-arm64-msvc": "1.2.6",
         "@rolldown/binding-win32-x64-msvc": "1.2.6"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -4226,6 +4903,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4244,6 +4928,27 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
@@ -4280,6 +4985,26 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-6.1.4.tgz",
+      "integrity": "sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -4294,6 +5019,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+      "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4379,6 +5150,16 @@
       },
       "peerDependencies": {
         "react": ">=15.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.1.tgz",
+      "integrity": "sha512-YQ3WlbqjYMmNpdvDH64jAgLjxuAR9+649calDWhbshYaeQGO2bR4nI94ORJmwI3J9YhoKQnpyGOK+0zlWS5N5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
@@ -4797,6 +5578,112 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/vitest": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-5.0.0.tgz",
+      "integrity": "sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/mocker": "5.0.0",
+        "chai": "^6.2.2",
+        "es-module-lexer": "^2.3.2",
+        "expect-type": "^1.4.0",
+        "magic-string": "^1.2.3",
+        "obug": "^2.1.4",
+        "picomatch": "^4.0.7",
+        "std-env": "^4.2.0",
+        "tinybench": "6.1.4",
+        "tinyexec": "1.3.0",
+        "tinyglobby": "^0.2.17",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^22.12.0 || ^24.0.0 || >=26.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "5.0.0",
+        "@vitest/browser-preview": "5.0.0",
+        "@vitest/browser-webdriverio": "^5.0.0-beta.5 || >=5.0.0",
+        "@vitest/coverage-istanbul": "5.0.0",
+        "@vitest/coverage-v8": "5.0.0",
+        "@vitest/ui": "5.0.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.4.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/warning": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
@@ -4804,6 +5691,41 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -4822,6 +5744,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4831,6 +5770,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/cg-arena-ui/package.json
+++ b/cg-arena-ui/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "vitest run",
     "preview": "vite preview",
     "format": "npx prettier --write ."
   },
@@ -30,6 +31,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@testing-library/react": "^16.3.3",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@types/react-syntax-highlighter": "^15.5.13",
@@ -38,9 +40,11 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.5",
     "globals": "^17.11.0",
+    "jsdom": "^30.0.1",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.68.0",
-    "vite": "^8.2.2"
+    "vite": "^8.2.2",
+    "vitest": "^5.0.0"
   },
   "allowScripts": {
     "@swc/core@1.16.1": true,

--- a/cg-arena-ui/src/api/index.ts
+++ b/cg-arena-ui/src/api/index.ts
@@ -12,8 +12,6 @@ import {
   ChartOverviewResponse,
   BotSourceCode,
   EnableMatchmakingRequest,
-  FetchMatchesResponse,
-  FetchMatchesRequest,
   MatchId,
   WatchReplayResponse,
 } from "@/models";
@@ -133,19 +131,6 @@ export const enableMatchmaking = async (enabled: boolean): Promise<void> => {
 
   const response = await fetch(req);
   await checkForErrors(response);
-};
-
-export const fetchMatches = async (
-  req: FetchMatchesRequest,
-): Promise<FetchMatchesResponse> => {
-  const query = new URLSearchParams({
-    filter: req.filter,
-    including_bots: req.includingBots.join(","),
-    offset: String(req.offset),
-    limit: String(req.limit),
-  });
-  const response = await fetch(`${host}/api/matches?${query}`);
-  return await parseResponse<FetchMatchesResponse>(response);
 };
 
 export const watchReplay = async (

--- a/cg-arena-ui/src/components/Leaderboard.tsx
+++ b/cg-arena-ui/src/components/Leaderboard.tsx
@@ -28,6 +28,7 @@ import {
 import { useState } from "react";
 import { useDialogs } from "@/hooks/useDialogs";
 import { Link } from "@tanstack/react-router";
+import { matchBrowsing } from "@/match-browsing";
 
 interface LeaderboardProps {
   lb: LeaderboardOverviewResponse;
@@ -243,10 +244,6 @@ const Row = ({ lb, item, stats, bot, selectedBotId }: RowProps) => {
     </Tooltip>
   );
 
-  const winsFilter = `bot(${selectedBotId}).rank < bot(${bot.id}).rank`;
-  const losesFilter = `bot(${selectedBotId}).rank > bot(${bot.id}).rank`;
-  const drawsFilter = `bot(${selectedBotId}).rank == bot(${bot.id}).rank`;
-
   return (
     <tr className={selected ? "highlighted-row" : ""}>
       <td>{item.rank + 1}</td>
@@ -267,59 +264,64 @@ const Row = ({ lb, item, stats, bot, selectedBotId }: RowProps) => {
       <RatingCell item={item} />
       {stats ? <WinrateCell stats={stats} /> : <td></td>}
       {stats && selectedBotId !== undefined ? (
-        <td>
-          <Link
-            to="/matches"
-            search={{
-              withBots: [selectedBotId, item.id],
-              filter: lb.filter
-                ? `(${lb.filter}) AND (${winsFilter})`
-                : winsFilter,
-            }}
-          >
-            {stats.wins}
-          </Link>
-          {" / "}
-          <Link
-            to="/matches"
-            search={{
-              withBots: [selectedBotId, item.id],
-              filter: lb.filter
-                ? `(${lb.filter}) AND (${losesFilter})`
-                : losesFilter,
-            }}
-          >
-            {stats.loses}
-          </Link>
-          {" / "}
-          <Link
-            to="/matches"
-            search={{
-              withBots: [selectedBotId, item.id],
-              filter: lb.filter
-                ? `(${lb.filter}) AND (${drawsFilter})`
-                : drawsFilter,
-            }}
-          >
-            {stats.draws}
-          </Link>
-        </td>
+        <HeadToHeadLinks
+          leaderboardFilter={lb.filter}
+          selectedBotId={selectedBotId}
+          opponentBotId={item.id}
+          stats={stats}
+        />
       ) : (
-        <td></td>
-      )}
-      {stats && selectedBotId !== undefined ? (
-        <td>
-          <Link
-            to="/matches"
-            search={{ withBots: [selectedBotId, item.id], filter: lb.filter }}
-          >
-            {stats.wins + stats.loses + stats.draws}
-          </Link>
-        </td>
-      ) : (
-        <td></td>
+        <>
+          <td></td>
+          <td></td>
+        </>
       )}
     </tr>
+  );
+};
+
+interface HeadToHeadLinksProps {
+  leaderboardFilter: string;
+  selectedBotId: BotId;
+  opponentBotId: BotId;
+  stats: WinrateStats;
+}
+
+const HeadToHeadLinks = ({
+  leaderboardFilter,
+  selectedBotId,
+  opponentBotId,
+  stats,
+}: HeadToHeadLinksProps) => {
+  const search = (result: "win" | "loss" | "draw" | "all") =>
+    matchBrowsing.leaderboardSearch({
+      leaderboardFilter,
+      selectedBotId,
+      opponentBotId,
+      result,
+    });
+
+  return (
+    <>
+      <td>
+        <Link to="/matches" search={search("win")}>
+          {stats.wins}
+        </Link>
+        {" / "}
+        <Link to="/matches" search={search("loss")}>
+          {stats.loses}
+        </Link>
+        {" / "}
+        <Link to="/matches" search={search("draw")}>
+          {stats.draws}
+        </Link>
+      </td>
+      <td>
+        <Link to="/matches" search={search("all")}>
+          {stats.wins + stats.loses + stats.draws}
+        </Link>
+      </td>
+    </>
   );
 };
 

--- a/cg-arena-ui/src/components/MatchCard.tsx
+++ b/cg-arena-ui/src/components/MatchCard.tsx
@@ -1,4 +1,4 @@
-import { MatchOverviewResponse } from "@/models";
+import { MatchOverview } from "@/match-browsing";
 import { FaHashtag, FaTrophy } from "react-icons/fa6";
 import { cn } from "@/lib/utils";
 import { LuCircleAlert } from "react-icons/lu";
@@ -7,7 +7,7 @@ import Identicon from "./Identicon";
 import { useDialogs } from "@/hooks/useDialogs";
 
 interface MatchCardProps {
-  match: MatchOverviewResponse;
+  match: MatchOverview;
 }
 
 const excludedAttrs = ["score", "index", "rank", "error"];

--- a/cg-arena-ui/src/main.tsx
+++ b/cg-arena-ui/src/main.tsx
@@ -15,6 +15,7 @@ import HomePage from "./pages/HomePage.tsx";
 import ConfigPage from "./pages/ConfigPage.tsx";
 import MatchesPage from "./pages/MatchesPage.tsx";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { matchBrowsing } from "@/match-browsing";
 import { z } from "zod";
 
 const rootRoute = createRootRoute({
@@ -34,12 +35,7 @@ const matchesRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/matches",
   component: () => <MatchesPage />,
-  validateSearch: z.object({
-    filter: z.string().catch("").default(""),
-    withBots: z.array(z.int()).catch([]).default([]),
-    page: z.int().min(1).catch(1).default(1),
-    pageSize: z.int().min(1).max(100).catch(10).default(10),
-  }),
+  validateSearch: matchBrowsing.routeSearch,
 });
 
 const configRoute = createRoute({

--- a/cg-arena-ui/src/match-browsing/index.test.tsx
+++ b/cg-arena-ui/src/match-browsing/index.test.tsx
@@ -1,0 +1,268 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { PropsWithChildren } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createMatchBrowsing,
+  MatchBrowseSearch,
+  MatchBrowsingAdapter,
+  MatchBrowsingView,
+  MatchResults,
+  MatchSearchRequest,
+  NavigateMatches,
+} from "./index";
+
+class InMemoryMatchAdapter implements MatchBrowsingAdapter {
+  readonly requests: MatchSearchRequest[] = [];
+
+  constructor(private readonly responses: Array<unknown | Error>) {}
+
+  async search(request: MatchSearchRequest): Promise<unknown> {
+    this.requests.push(request);
+    const response = this.responses.shift();
+    if (response instanceof Error) {
+      throw response;
+    }
+    return response;
+  }
+}
+
+function results(id: number, hasMore: boolean): MatchResults {
+  return {
+    matches: [
+      {
+        id,
+        participants: [],
+        seed: String(id),
+        attributes: [],
+      },
+    ],
+    has_more: hasMore,
+  };
+}
+
+function renderBrowsing(
+  adapter: InMemoryMatchAdapter,
+  initialSearch: MatchBrowseSearch,
+) {
+  const browsing = createMatchBrowsing(adapter);
+  const transitions: MatchBrowseSearch[] = [];
+  const navigate: NavigateMatches = (search) => transitions.push(search);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { gcTime: 0 } },
+  });
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  const hook = renderHook<
+    MatchBrowsingView,
+    { search: MatchBrowseSearch; navigate: NavigateMatches }
+  >(
+    ({ search, navigate: nextNavigate }) =>
+      browsing.useMatches(search, nextNavigate),
+    {
+      wrapper,
+      initialProps: { search: initialSearch, navigate },
+    },
+  );
+
+  return { browsing, transitions, navigate, ...hook };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("match-browsing interface", () => {
+  it("canonicalizes route defaults and builds complete head-to-head links", () => {
+    const browsing = createMatchBrowsing(new InMemoryMatchAdapter([]));
+
+    expect(
+      browsing.routeSearch.parse({
+        page: 0,
+        pageSize: 101,
+        withBots: "not-an-array",
+      }),
+    ).toEqual({ filter: "", withBots: [], page: 1, pageSize: 10 });
+
+    const leaderboardFilter = 'match.label == "A&B+#"';
+    for (const [result, operator] of [
+      ["win", "<"],
+      ["loss", ">"],
+      ["draw", "=="],
+    ] as const) {
+      expect(
+        browsing.leaderboardSearch({
+          leaderboardFilter,
+          selectedBotId: 7,
+          opponentBotId: 9,
+          result,
+        }),
+      ).toEqual({
+        filter: `(${leaderboardFilter}) AND (bot(7).rank ${operator} bot(9).rank)`,
+        withBots: [7, 9],
+        page: 1,
+        pageSize: 10,
+      });
+    }
+    expect(
+      browsing.leaderboardSearch({
+        leaderboardFilter,
+        selectedBotId: 7,
+        opponentBotId: 9,
+        result: "all",
+      }).filter,
+    ).toBe(leaderboardFilter);
+  });
+
+  it("owns request encoding, URL transitions, and page eligibility", async () => {
+    const filter = 'match.label == "A&B+#"';
+    const adapter = new InMemoryMatchAdapter([
+      results(101, true),
+      results(102, false),
+    ]);
+    const initialSearch = {
+      filter,
+      withBots: [7, 9],
+      page: 1,
+      pageSize: 25,
+    };
+    const { result, rerender, transitions, navigate } = renderBrowsing(
+      adapter,
+      initialSearch,
+    );
+
+    await waitFor(() =>
+      expect(result.current.results?.matches[0].id).toBe(101),
+    );
+    expect(adapter.requests[0]).toEqual({
+      filter,
+      includingBots: [7, 9],
+      offset: 0,
+      limit: 25,
+    });
+    expect(result.current.canGoNext).toBe(true);
+
+    act(() => result.current.goToPage(2));
+    expect(transitions).toEqual([{ ...initialSearch, page: 2 }]);
+    rerender({ search: transitions[0], navigate });
+
+    await waitFor(() =>
+      expect(result.current.results?.matches[0].id).toBe(102),
+    );
+    expect(adapter.requests[1]).toEqual({
+      filter,
+      includingBots: [7, 9],
+      offset: 25,
+      limit: 25,
+    });
+    expect(result.current.canGoNext).toBe(false);
+    expect(result.current.canGoPrevious).toBe(true);
+
+    act(() => result.current.goToPage(3));
+    expect(transitions).toHaveLength(1);
+    act(() => result.current.goToPage(1));
+    expect(transitions[1]).toEqual(initialSearch);
+  });
+
+  it("refreshes an unchanged search and resets changed criteria to page one", async () => {
+    const adapter = new InMemoryMatchAdapter([
+      results(201, false),
+      results(202, false),
+    ]);
+    const initialSearch = {
+      filter: "match.player_count == 2",
+      withBots: [1, 2],
+      page: 1,
+      pageSize: 10,
+    };
+    const { result, transitions } = renderBrowsing(adapter, initialSearch);
+
+    await waitFor(() =>
+      expect(result.current.results?.matches[0].id).toBe(201),
+    );
+    act(() =>
+      result.current.submit({
+        filter: initialSearch.filter,
+        withBots: initialSearch.withBots,
+        pageSize: initialSearch.pageSize,
+      }),
+    );
+    await waitFor(() => expect(adapter.requests).toHaveLength(2));
+    await waitFor(() =>
+      expect(result.current.results?.matches[0].id).toBe(202),
+    );
+    expect(transitions).toHaveLength(0);
+
+    act(() =>
+      result.current.submit({
+        filter: "match.player_count == 3",
+        withBots: [1],
+        pageSize: 50,
+      }),
+    );
+    expect(transitions).toEqual([
+      {
+        filter: "match.player_count == 3",
+        withBots: [1],
+        page: 1,
+        pageSize: 50,
+      },
+    ]);
+  });
+
+  it("retains the last success across request and response-validation errors", async () => {
+    const adapter = new InMemoryMatchAdapter([
+      results(301, true),
+      new Error("Invalid filter expression"),
+      { matches: [], has_more: "yes" },
+    ]);
+    const initialSearch = {
+      filter: "",
+      withBots: [],
+      page: 1,
+      pageSize: 10,
+    };
+    const { result, rerender, transitions, navigate } = renderBrowsing(
+      adapter,
+      initialSearch,
+    );
+
+    await waitFor(() =>
+      expect(result.current.results?.matches[0].id).toBe(301),
+    );
+
+    act(() =>
+      result.current.submit({
+        filter: "invalid(",
+        withBots: [],
+        pageSize: 10,
+      }),
+    );
+    rerender({ search: transitions[0], navigate });
+    await waitFor(() =>
+      expect(result.current.errorMessage).toBe("Invalid filter expression"),
+    );
+    expect(result.current.results?.matches[0].id).toBe(301);
+    expect(result.current.showingRetainedResults).toBe(true);
+    expect(result.current.canGoNext).toBe(false);
+
+    act(() =>
+      result.current.submit({
+        filter: "match.player_count == 2",
+        withBots: [],
+        pageSize: 10,
+      }),
+    );
+    rerender({ search: transitions[1], navigate });
+    await waitFor(() =>
+      expect(result.current.errorMessage).toMatch(/^Invalid match response:/),
+    );
+    expect(result.current.errorMessage).toContain("has_more");
+    expect(result.current.results?.matches[0].id).toBe(301);
+    expect(result.current.showingRetainedResults).toBe(true);
+  });
+});

--- a/cg-arena-ui/src/match-browsing/index.ts
+++ b/cg-arena-ui/src/match-browsing/index.ts
@@ -1,0 +1,319 @@
+import {
+  keepPreviousData,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { useCallback, useEffect, useState } from "react";
+import { z } from "zod";
+
+import { BotId } from "@/models";
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 10;
+const MATCH_QUERY_KEY = ["match-browsing"] as const;
+
+const routeSearchSchema = z.object({
+  filter: z.string().catch("").default(""),
+  withBots: z.array(z.int()).catch([]).default([]),
+  page: z.int().min(1).catch(DEFAULT_PAGE).default(DEFAULT_PAGE),
+  pageSize: z
+    .int()
+    .min(1)
+    .max(100)
+    .catch(DEFAULT_PAGE_SIZE)
+    .default(DEFAULT_PAGE_SIZE),
+});
+
+const matchResultsSchema = z.object({
+  matches: z.array(
+    z.object({
+      id: z.int(),
+      participants: z.array(
+        z.object({
+          rank: z.int(),
+          index: z.int(),
+          bot_id: z.int(),
+          bot_name: z.string(),
+          error: z.boolean(),
+        }),
+      ),
+      seed: z.string(),
+      attributes: z.array(
+        z.object({
+          name: z.string(),
+          bot_id: z.int().nullable(),
+          turn: z.int().nullable(),
+          value: z.string(),
+        }),
+      ),
+    }),
+  ),
+  has_more: z.boolean(),
+});
+
+export type MatchBrowseSearch = z.output<typeof routeSearchSchema>;
+export type MatchOverview = z.output<
+  (typeof matchResultsSchema)["shape"]["matches"]["element"]
+>;
+export type MatchResults = z.output<typeof matchResultsSchema>;
+
+export interface MatchSearchRequest {
+  filter: string;
+  includingBots: BotId[];
+  offset: number;
+  limit: number;
+}
+
+/** Port implemented by the production HTTP adapter and by interface tests in memory. */
+export interface MatchBrowsingAdapter {
+  search(request: MatchSearchRequest): Promise<unknown>;
+}
+
+export interface MatchSearchDraft {
+  filter: string;
+  withBots: BotId[];
+  pageSize: number;
+}
+
+export interface HeadToHeadMatchLink {
+  leaderboardFilter: string;
+  selectedBotId: BotId;
+  opponentBotId: BotId;
+  result: "win" | "loss" | "draw" | "all";
+}
+
+export interface MatchBrowsingView {
+  search: MatchBrowseSearch;
+  results: MatchResults | undefined;
+  errorMessage: string | undefined;
+  isFetching: boolean;
+  showingRetainedResults: boolean;
+  canGoPrevious: boolean;
+  canGoNext: boolean;
+  submit(draft: MatchSearchDraft): void;
+  goToPage(page: number): void;
+}
+
+export type NavigateMatches = (search: MatchBrowseSearch) => void;
+
+/**
+ * The complete match-browsing interface. Callers supply user intent and render
+ * the returned view; URL policy, filter composition, paging, requests,
+ * validation, refreshes, errors, and retained results remain behind this seam.
+ */
+export interface MatchBrowsing {
+  readonly routeSearch: typeof routeSearchSchema;
+  leaderboardSearch(link: HeadToHeadMatchLink): MatchBrowseSearch;
+  useMatches(
+    search: MatchBrowseSearch,
+    navigate: NavigateMatches,
+  ): MatchBrowsingView;
+}
+
+export function createMatchBrowsing(
+  adapter: MatchBrowsingAdapter,
+): MatchBrowsing {
+  return {
+    routeSearch: routeSearchSchema,
+    leaderboardSearch,
+    useMatches(search, navigate) {
+      return useMatchBrowsing(adapter, search, navigate);
+    },
+  };
+}
+
+function leaderboardSearch({
+  leaderboardFilter,
+  selectedBotId,
+  opponentBotId,
+  result,
+}: HeadToHeadMatchLink): MatchBrowseSearch {
+  let resultFilter = "";
+  if (result !== "all") {
+    const operator = { win: "<", loss: ">", draw: "==" }[result];
+    resultFilter = `bot(${selectedBotId}).rank ${operator} bot(${opponentBotId}).rank`;
+  }
+
+  const filter =
+    leaderboardFilter && resultFilter
+      ? `(${leaderboardFilter}) AND (${resultFilter})`
+      : leaderboardFilter || resultFilter;
+
+  return routeSearchSchema.parse({
+    filter,
+    withBots: [selectedBotId, opponentBotId],
+    page: DEFAULT_PAGE,
+    pageSize: DEFAULT_PAGE_SIZE,
+  });
+}
+
+function useMatchBrowsing(
+  adapter: MatchBrowsingAdapter,
+  unvalidatedSearch: MatchBrowseSearch,
+  navigate: NavigateMatches,
+): MatchBrowsingView {
+  const search = routeSearchSchema.parse(unvalidatedSearch);
+  const queryClient = useQueryClient();
+  const [lastSuccessfulResults, setLastSuccessfulResults] =
+    useState<MatchResults>();
+  const query = useQuery({
+    queryKey: [
+      ...MATCH_QUERY_KEY,
+      search.filter,
+      search.withBots,
+      search.page,
+      search.pageSize,
+    ],
+    queryFn: async () => {
+      const response = await adapter.search({
+        filter: search.filter,
+        includingBots: search.withBots,
+        offset: (search.page - 1) * search.pageSize,
+        limit: search.pageSize,
+      });
+      const parsed = matchResultsSchema.safeParse(response);
+      if (!parsed.success) {
+        const details = parsed.error.issues
+          .map((issue) => {
+            const location =
+              issue.path.length > 0 ? issue.path.join(".") : "response";
+            return `${location}: ${issue.message}`;
+          })
+          .join("; ");
+        throw new Error(`Invalid match response: ${details}`);
+      }
+      return parsed.data;
+    },
+    placeholderData: keepPreviousData,
+    retry: false,
+  });
+
+  useEffect(
+    () =>
+      queryClient.getQueryCache().subscribe((event) => {
+        if (
+          event.type === "updated" &&
+          event.query.queryKey[0] === MATCH_QUERY_KEY[0] &&
+          event.query.state.status === "success"
+        ) {
+          setLastSuccessfulResults(event.query.state.data as MatchResults);
+        }
+      }),
+    [queryClient],
+  );
+
+  const rememberCurrentResults = useCallback(() => {
+    if (
+      query.data !== undefined &&
+      !query.isPlaceholderData &&
+      !query.isError
+    ) {
+      setLastSuccessfulResults(query.data);
+    }
+  }, [query.data, query.isError, query.isPlaceholderData]);
+
+  const displayedResults = query.data ?? lastSuccessfulResults;
+  const canGoNext =
+    !query.isError && !query.isFetching && displayedResults?.has_more === true;
+
+  const submit = useCallback(
+    (draft: MatchSearchDraft) => {
+      rememberCurrentResults();
+      const nextSearch = routeSearchSchema.parse({
+        ...draft,
+        page: DEFAULT_PAGE,
+      });
+
+      if (searchesMatch(search, nextSearch)) {
+        void query.refetch();
+      } else {
+        navigate(nextSearch);
+      }
+    },
+    [navigate, query, rememberCurrentResults, search],
+  );
+
+  const goToPage = useCallback(
+    (page: number) => {
+      rememberCurrentResults();
+      if (
+        page < DEFAULT_PAGE ||
+        (page > search.page &&
+          (query.isError ||
+            query.isFetching ||
+            displayedResults?.has_more !== true))
+      ) {
+        return;
+      }
+      navigate({ ...search, page });
+    },
+    [
+      displayedResults?.has_more,
+      navigate,
+      query.isError,
+      query.isFetching,
+      rememberCurrentResults,
+      search,
+    ],
+  );
+
+  const errorMessage = query.isError
+    ? query.error instanceof Error
+      ? query.error.message
+      : String(query.error)
+    : undefined;
+
+  return {
+    search,
+    results: displayedResults,
+    errorMessage,
+    isFetching: query.isFetching,
+    showingRetainedResults:
+      query.isError && lastSuccessfulResults !== undefined,
+    canGoPrevious: search.page > DEFAULT_PAGE && !query.isFetching,
+    canGoNext,
+    submit,
+    goToPage,
+  };
+}
+
+function searchesMatch(left: MatchBrowseSearch, right: MatchBrowseSearch) {
+  return (
+    left.filter === right.filter &&
+    left.page === right.page &&
+    left.pageSize === right.pageSize &&
+    left.withBots.length === right.withBots.length &&
+    left.withBots.every((botId, index) => botId === right.withBots[index])
+  );
+}
+
+const apiHost = import.meta.env.DEV ? "http://127.0.0.1:1234" : "";
+
+const httpAdapter: MatchBrowsingAdapter = {
+  async search(request) {
+    const query = new URLSearchParams({
+      filter: request.filter,
+      including_bots: request.includingBots.join(","),
+      offset: String(request.offset),
+      limit: String(request.limit),
+    });
+    const response = await fetch(`${apiHost}/api/matches?${query}`);
+    await checkForErrors(response);
+    return await response.json();
+  },
+};
+
+async function checkForErrors(response: Response) {
+  if (response.status >= 500) {
+    throw new Error("Internal server error");
+  }
+  if (!response.ok) {
+    const body = (await response.json()) as {
+      error_code?: string;
+      message?: string;
+    };
+    throw new Error(body.message ?? body.error_code ?? "Request failed");
+  }
+}
+
+export const matchBrowsing = createMatchBrowsing(httpAdapter);

--- a/cg-arena-ui/src/models/index.ts
+++ b/cg-arena-ui/src/models/index.ts
@@ -98,40 +98,6 @@ export interface EnableMatchmakingRequest {
   enabled: boolean;
 }
 
-export interface FetchMatchesRequest {
-  filter: string;
-  includingBots: number[];
-  offset: number;
-  limit: number;
-}
-
-export interface FetchMatchesResponse {
-  matches: MatchOverviewResponse[];
-  has_more: boolean;
-}
-
-export interface MatchOverviewResponse {
-  id: number;
-  participants: ParticipantOverviewResponse[];
-  seed: string;
-  attributes: MatchAttributeResponse[];
-}
-
-export interface MatchAttributeResponse {
-  name: string;
-  bot_id: BotId | null;
-  turn: number | null;
-  value: string;
-}
-
-export interface ParticipantOverviewResponse {
-  rank: number;
-  index: number;
-  bot_id: BotId;
-  bot_name: string;
-  error: boolean;
-}
-
 export interface WatchReplayResponse {
   session_id: string;
   viewer_url: string;

--- a/cg-arena-ui/src/pages/MatchesPage.tsx
+++ b/cg-arena-ui/src/pages/MatchesPage.tsx
@@ -1,15 +1,13 @@
-import { fetchMatches } from "@/api";
 import { MatchCard } from "@/components/MatchCard";
 import { useAppStore } from "@/hooks/useAppStore";
 import {
-  BotId,
-  BotOverviewResponse,
-  FetchMatchesResponse,
-  MatchOverviewResponse,
-} from "@/models";
-import { keepPreviousData, useQuery } from "@tanstack/react-query";
+  matchBrowsing,
+  MatchBrowseSearch,
+  MatchOverview,
+} from "@/match-browsing";
+import { BotId, BotOverviewResponse } from "@/models";
 import { getRouteApi, useNavigate } from "@tanstack/react-router";
-import { FormEvent, useState } from "react";
+import { FormEvent, useCallback, useState } from "react";
 import {
   Alert,
   Badge,
@@ -25,88 +23,28 @@ const routeApi = getRouteApi("/matches");
 
 const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
 
-function botIdsMatch(left: BotId[], right: BotId[]) {
-  return (
-    left.length === right.length &&
-    left.every((botId, index) => botId === right[index])
-  );
-}
-
 export default function MatchesPage() {
-  const { filter, withBots, page, pageSize } = routeApi.useSearch();
+  const routeSearch = routeApi.useSearch();
   const navigate = useNavigate();
+  const navigateMatches = useCallback(
+    (search: MatchBrowseSearch) => {
+      void navigate({ to: "/matches", search });
+    },
+    [navigate],
+  );
+  const browsing = matchBrowsing.useMatches(routeSearch, navigateMatches);
+  const { filter, withBots, page, pageSize } = browsing.search;
   const bots = useAppStore((state) => state.bots);
-  const [lastSuccessfulResults, setLastSuccessfulResults] =
-    useState<FetchMatchesResponse>();
-
-  const matchesQuery = useQuery({
-    queryKey: ["matches", filter, withBots, page, pageSize],
-    queryFn: () =>
-      fetchMatches({
-        filter,
-        includingBots: withBots,
-        offset: (page - 1) * pageSize,
-        limit: pageSize,
-      }),
-    placeholderData: keepPreviousData,
-    retry: false,
-  });
-
-  const displayedResults = matchesQuery.data ?? lastSuccessfulResults;
-  const rememberCurrentResults = () => {
-    if (
-      matchesQuery.data !== undefined &&
-      !matchesQuery.isPlaceholderData &&
-      !matchesQuery.isError
-    ) {
-      setLastSuccessfulResults(matchesQuery.data);
-    }
-  };
-  const errorMessage =
-    matchesQuery.error instanceof Error
-      ? matchesQuery.error.message
-      : String(matchesQuery.error);
 
   const handleSearch = (
     nextFilter: string,
     nextWithBots: BotId[],
     nextPageSize: number,
   ) => {
-    rememberCurrentResults();
-    if (
-      page === 1 &&
-      filter === nextFilter &&
-      pageSize === nextPageSize &&
-      botIdsMatch(withBots, nextWithBots)
-    ) {
-      void matchesQuery.refetch();
-      return;
-    }
-
-    void navigate({
-      to: "/matches",
-      search: {
-        filter: nextFilter,
-        withBots: nextWithBots,
-        page: 1,
-        pageSize: nextPageSize,
-      },
-    });
-  };
-
-  const goToPage = (nextPage: number) => {
-    rememberCurrentResults();
-    if (
-      nextPage < 1 ||
-      (nextPage > page &&
-        (matchesQuery.isError || displayedResults?.has_more !== true))
-    ) {
-      return;
-    }
-
-    void navigate({
-      to: "/matches",
-      search: { filter, withBots, page: nextPage, pageSize },
+    browsing.submit({
+      filter: nextFilter,
+      withBots: nextWithBots,
+      pageSize: nextPageSize,
     });
   };
 
@@ -124,7 +62,7 @@ export default function MatchesPage() {
             onSearch={handleSearch}
           />
 
-          {matchesQuery.isFetching && (
+          {browsing.isFetching && (
             <div
               className="d-flex align-items-center gap-2 text-body-secondary"
               role="status"
@@ -134,13 +72,13 @@ export default function MatchesPage() {
             </div>
           )}
 
-          {matchesQuery.isError && (
+          {browsing.errorMessage !== undefined && (
             <Alert variant="danger" className="mb-0">
               <Alert.Heading>Could not search matches</Alert.Heading>
-              <p>{errorMessage}</p>
+              <p>{browsing.errorMessage}</p>
               <p className="mb-0">
                 Fix the filter or required bots, then search again.
-                {lastSuccessfulResults !== undefined &&
+                {browsing.showingRetainedResults &&
                   " Your last successful results are still shown below."}
               </p>
             </Alert>
@@ -148,15 +86,15 @@ export default function MatchesPage() {
         </Card.Body>
       </Card>
 
-      {displayedResults !== undefined && (
-        <MatchList matches={displayedResults.matches} />
+      {browsing.results !== undefined && (
+        <MatchList matches={browsing.results.matches} />
       )}
 
       <div className="d-flex justify-content-center">
         <Pagination className="mb-0">
           <Pagination.Prev
-            disabled={page === 1 || matchesQuery.isFetching}
-            onClick={() => goToPage(page - 1)}
+            disabled={!browsing.canGoPrevious}
+            onClick={() => browsing.goToPage(page - 1)}
           >
             Prev
           </Pagination.Prev>
@@ -164,12 +102,8 @@ export default function MatchesPage() {
             {page}
           </Pagination.Item>
           <Pagination.Next
-            disabled={
-              matchesQuery.isError ||
-              displayedResults?.has_more !== true ||
-              matchesQuery.isFetching
-            }
-            onClick={() => goToPage(page + 1)}
+            disabled={!browsing.canGoNext}
+            onClick={() => browsing.goToPage(page + 1)}
           >
             Next
           </Pagination.Next>
@@ -286,7 +220,7 @@ function MatchesFilters({
 }
 
 interface MatchListProps {
-  matches: MatchOverviewResponse[];
+  matches: MatchOverview[];
 }
 
 export function MatchList({ matches }: MatchListProps) {


### PR DESCRIPTION
## Summary
- introduce one documented match-browsing interface for canonical route state, leaderboard filters, paging, refreshes, result retention, and runtime validation
- move match request encoding into the production HTTP adapter and use the interface from MatchesPage and Leaderboard
- add in-memory adapter interface coverage for transitions, request semantics, paging, errors, retained results, and malformed responses

## Verification
- `npm test`
- `npm run lint`
- `npm run build`
- browser smoke: a failed search kept the prior Alpha/Beta result visible, displayed validation feedback, canonicalized the URL, and disabled forward paging

Closes #16