### PR TITLE
Add native CodinGame referee JAR adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,7 @@ dependencies = [
  "clap",
  "indoc",
  "itertools",
+ "libc",
  "local-ip-address",
  "log",
  "mime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ log = "0.4"
 nalgebra = "0.34.1"
 shell-words = "1.1"
 uuid = { version = "1.18", features = ["v4"] }
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3.20"

--- a/assets/CommandLineInterface.java
+++ b/assets/CommandLineInterface.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.common.io.Files;
+import org.apache.commons.cli.Option;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
@@ -18,6 +19,8 @@ import java.util.List;
 import java.util.Properties;
 
 public class CommandLineInterface {
+    private static final String CGARENA_COMPATIBILITY_VERSION = "cgarena-referee-v1";
+
 
     public static void main(String[] args) {
         try {
@@ -46,9 +49,18 @@ public class CommandLineInterface {
                     .addOption("r", true, "File input for replay")
                     .addOption("l", true, "File output for logs")
                     .addOption("seed", true, "Seed")
-                    .addOption("port", true, "Replay server port");
+                    .addOption("port", true, "Replay server port")
+                    .addOption(Option.builder()
+                            .longOpt("cgarena-compat")
+                            .desc("Print the CG Arena referee compatibility version")
+                            .build());
 
             CommandLine cmd = new DefaultParser().parse(options, args);
+
+            if (cmd.hasOption("cgarena-compat")) {
+                System.out.println(CGARENA_COMPATIBILITY_VERSION);
+                return;
+            }
 
             int playerCount = 0;
             // CG supports multiplayer games up to 8 players

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -31,7 +31,7 @@ file = "cgarena.log"
 # `referee` selects exactly one match/replay integration:
 # - codingame_jar runs a compatible shaded CodinGame JAR directly.
 # - command preserves the custom referee command contract.
-# codingame_jar requires an executable JAR implementing -p1..-p8, -seed, -l, -r, and -port.
+# codingame_jar requires -p1..-p8, -seed, -l, -r, -port, and --cgarena-compat.
 # cmd_build builds a bot and cmd_run returns its complete command line.
 # 'cmd_build' should output bot's executable to the same folder
 [[workers]]
@@ -43,7 +43,7 @@ cmd_run = "./{DIR}/a"
 [workers.referee]
 type = "codingame_jar"
 path = "referee/target/referee.jar"
- 
+
 
 # or a generic version
 # cmd_run = "sh run.sh {DIR} {LANG}"

--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -27,40 +27,23 @@ expose = false
 level = "INFO"
 file = "cgarena.log"
 
-# list of the arena workers, currently only list with single "embedded" worker is supported
-# use 'type' = "embedded" for worker embedded into arena
-# 'threads' controls how many games can be run in parallel
-# 'cmd_play_match' runs one match and must create the file named by {REPLAY_PATH}.
-# It should print JSON to stdout in the following format:
-#   { "ranks": [..], "errors": [..], "attributes": [..] }
-#   where "ranks" is the list of zero-based final placements; duplicates represent draws
-#   where "errors" - list of numbers where i-th number is 1 if i-th match participant failed during match or 0 otherwise
-#   where "attributes" - list of match attributes emitted by the bot. Each attribute is json object with the following fields:
-#       - "name" - name of attribute
-#       - "player" - index of a player who the attribute belongs to (or null if it's match attribute, not specific to a particular bot)
-#       - "turn" - turn of the attribute (or null if the attribute is not specific to any particular turn)
-#       - "value" - attribute value (integer, float or string)
-#
-# 'cmd_build' is a command to build a bot
-# 'cmd_run' is a command to run bot
-# 'cmd_watch_replay' must generate a static replay bundle containing test.html in {REPLAY_DIR},
-# then exit. Startup is limited to 30 seconds. Replay bundles are served beneath the arena origin.
-# the above commands will have the following replacements applied:
-# - {SEED} is replaced with the match seed
-# - {REPLAY_PATH} is replaced with the replay artifact path for cmd_play_match and cmd_watch_replay
-# - {REPLAY_DIR}, {PORT}, and {PLAYER_COUNT} are replaced for cmd_watch_replay
-# - {P1}, {P2}, etc. are replaced with 'cmd_run' configured for match participant 1, 2, etc.
-# - {PLAYERS} is replaced with concatenated player commands. Use this for varying player counts.
-# - {DIR} is replaced with the target bot directory
-# - {LANG} is replaced with the target bot language
+# one embedded worker is currently supported; threads controls concurrent matches.
+# `referee` selects exactly one match/replay integration:
+# - codingame_jar runs a compatible shaded CodinGame JAR directly.
+# - command preserves the custom referee command contract.
+# codingame_jar requires an executable JAR implementing -p1..-p8, -seed, -l, -r, and -port.
+# cmd_build builds a bot and cmd_run returns its complete command line.
 # 'cmd_build' should output bot's executable to the same folder
 [[workers]]
 type = "embedded"
 threads = 1
-cmd_play_match = "python3 play_game.py {SEED} {REPLAY_PATH} {PLAYERS}"
-cmd_watch_replay = "python3 watch_replay.py {REPLAY_PATH} {REPLAY_DIR} {PORT} {PLAYER_COUNT}"
 cmd_build = "g++ -std=c++20 -x c++ {DIR}/source.txt -o {DIR}/a"
 cmd_run = "./{DIR}/a"
+
+[workers.referee]
+type = "codingame_jar"
+path = "referee/target/referee.jar"
+ 
 
 # or a generic version
 # cmd_run = "sh run.sh {DIR} {LANG}"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -223,7 +223,7 @@ Select exactly one referee adapter.
 
 #### `codingame_jar`
 
-Runs a CG-Arena-compatible shaded CodinGame referee JAR directly. The JAR must be executable with `java -jar` and implement the maintained `-p1` through `-p8`, `-seed`, `-l`, `-r`, and `-port` contract. CG Arena owns match-result conversion, replay persistence, static replay-bundle extraction, and renderer cleanup.
+Runs a CG-Arena-compatible shaded CodinGame referee JAR directly. The JAR must be executable with `java -jar`, implement the maintained `-p1` through `-p8`, `-seed`, `-l`, `-r`, and `-port` contract, and report `cgarena-referee-v1` for `--cgarena-compat`. CG Arena probes that version marker at startup, then owns match-result conversion, replay persistence, static replay-bundle extraction, and renderer cleanup.
 
 ```toml
 [workers.referee]
@@ -245,8 +245,9 @@ watch_replay = "my-renderer {REPLAY_PATH} {REPLAY_DIR} {PORT} {PLAYER_COUNT}"
 ```
 
 Legacy configurations with both `cmd_play_match` and `cmd_watch_replay` directly under
-`[[workers]]` continue to load as a `command` referee. New configuration must use the tagged
-table above. Do not configure both forms; CG Arena rejects the ambiguous configuration.
+`[[workers]]` continue to load as a `command` referee with their previous validation rules.
+New configuration must use the tagged table above and include every shown placeholder. Do not
+configure both forms; CG Arena rejects the ambiguous configuration.
 
 `cmd_run` is expanded once per participant. CG Arena passes each resulting command as one player argument to the JAR adapter; it is never shell-split.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -217,108 +217,34 @@ Type of worker. Currently only `"embedded"` is supported.
 
 Controls the number of concurrent matches being run. Don't set this higher than the number of cpu cores you have.
 
-### `cmd_play_match`
+### `referee`
 
-CG Arena executes `cmd_play_match` once per scheduled match. The command is parsed into
-an executable and arguments; it is not passed through a shell. Quote literal arguments in
-the configuration when they contain spaces.
+Select exactly one referee adapter.
 
-CG Arena applies these substitutions:
+#### `codingame_jar`
 
-- `{SEED}` - match seed
-- `{REPLAY_PATH}` - a unique path owned by this match, under the arena's `replays` directory
-- `{P1}`, `{P2}`, ... - `cmd_run` configured for that participant
-- `{PLAYERS}` - all configured participant commands as separate arguments; use this for variable player counts
-
-Example on macOS/Linux:
+Runs a CG-Arena-compatible shaded CodinGame referee JAR directly. The JAR must be executable with `java -jar` and implement the maintained `-p1` through `-p8`, `-seed`, `-l`, `-r`, and `-port` contract. CG Arena owns match-result conversion, replay persistence, static replay-bundle extraction, and renderer cleanup.
 
 ```toml
-cmd_play_match = "python3 play_game.py {SEED} {REPLAY_PATH} {PLAYERS}"
+[workers.referee]
+type = "codingame_jar"
+path = "referee/target/referee.jar"
+# java = "java"
+# league = 19
 ```
 
-On Windows, install Python 3 and use its configured launcher, for example:
+#### `command`
+
+Use this adapter for custom or non-Java referees. `play_match` must produce CG Arena's established JSON match result and write the owned `{REPLAY_PATH}` artifact. `watch_replay` must create `{REPLAY_DIR}/test.html`.
 
 ```toml
-cmd_play_match = "py -3 play_game.py {SEED} {REPLAY_PATH} {PLAYERS}"
+[workers.referee]
+type = "command"
+play_match = "my-referee {SEED} {REPLAY_PATH} {PLAYERS}"
+watch_replay = "my-renderer {REPLAY_PATH} {REPLAY_DIR} {PORT} {PLAYER_COUNT}"
 ```
 
-The command must write the replay to `{REPLAY_PATH}`. A successful match that produces
-no non-empty artifact is still recorded, but replay is unavailable. Existing matches from
-arenas created before replay-path persistence are also unavailable; CG Arena never guesses
-an artifact from their seed.
-
-The command must print JSON to stdout in the following format:
-
-```json
-{ "ranks": [0, 1], "errors": [0, 0], "attributes": [] }
-```
-
-Where:
-
-- `ranks` - the list of numbers where i-th number is i-th match participant final placement (e.g. 0 for winner). Duplicates are allowed in the case of draw.
-- `errors` - the list of numbers where i-th number is 1 if i-th match participant failed during match or 0 otherwise
-- `attributes` - the list of match attributes emitted by the bot. Each attribute is a json object with the following fields:
-
-    - `name` - name of attribute
-    - `player` - index of a player who the attribute belongs to (or `null` if it's match attribute, not specific to a particular bot)
-    - `turn` - turn of the attribute (or `null` if the attribute is not specific to any particular turn)
-    - `value` - the attribute value (integer, float or string)
-
-Example:
-
-```js
-{
-    "ranks": [0, 1],
-    "errors": [0, 0],
-    "attributes": [
-        {
-            "name": "map_size",
-            "value": 16
-        },
-        {
-            "name": "final_score",
-            "player": 0,
-            "value": 86
-        },
-        {
-            "name": "final_score",
-            "player": 1,
-            "value": 53
-        },
-    ],
-}
-```
-
-### `cmd_watch_replay`
-
-`cmd_watch_replay` converts one persisted artifact into a static replay bundle. CG Arena
-runs it outside the arena actor, limits startup to 30 seconds, terminates and reaps failures,
-and requires the command to exit successfully. The command must create `{REPLAY_DIR}/test.html`;
-stdout is ignored.
-
-Substitutions:
-
-- `{REPLAY_PATH}` - absolute path to the persisted artifact
-- `{REPLAY_DIR}` - empty, session-owned output directory
-- `{PORT}` - an ephemeral loopback port for a renderer that needs a temporary HTTP listener
-- `{PLAYER_COUNT}` - participant count persisted with the match
-
-Example on macOS/Linux:
-
-```toml
-cmd_watch_replay = "python3 watch_replay.py {REPLAY_PATH} {REPLAY_DIR} {PORT} {PLAYER_COUNT}"
-```
-
-On Windows, replace `python3` with the installed launcher, for example `py -3`.
-`watch_replay.py` validates Python, Java, the referee JAR, the artifact JSON, and participant
-count before rendering. It invokes Java with an argument list, copies the generated static
-bundle, terminates the temporary Java renderer, and exits. CG Arena serves each bundle at
-`/api/replays/{session_id}/...` under its own origin; renderer ports are loopback-only and
-never sent to browsers.
-
-Each replay dialog owns a distinct session. Closing one session cannot affect another.
-Inactive sessions expire after 15 minutes, and all session directories are removed on arena
-shutdown.
+`cmd_run` is expanded once per participant. CG Arena passes each resulting command as one player argument to the JAR adapter; it is never shell-split.
 
 ### `cmd_build`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -244,6 +244,10 @@ play_match = "my-referee {SEED} {REPLAY_PATH} {PLAYERS}"
 watch_replay = "my-renderer {REPLAY_PATH} {REPLAY_DIR} {PORT} {PLAYER_COUNT}"
 ```
 
+Legacy configurations with both `cmd_play_match` and `cmd_watch_replay` directly under
+`[[workers]]` continue to load as a `command` referee. New configuration must use the tagged
+table above. Do not configure both forms; CG Arena rejects the ambiguous configuration.
+
 `cmd_run` is expanded once per participant. CG Arena passes each resulting command as one player argument to the JAR adapter; it is never shell-split.
 
 ### `cmd_build`
@@ -261,7 +265,7 @@ cmd_build = "sh build.sh {DIR} {LANG}"
 
 ### `cmd_run`
 
-This command is passed to `cmd_play_match` after applying substitutions for each bot.
+This command is passed to the configured referee after applying substitutions for each bot.
 
 The substitutions for `cmd_run` are same as for `cmd_build`:
 - `{DIR}` would be replaced with target bot directory

--- a/docs/example_codingame_setup.md
+++ b/docs/example_codingame_setup.md
@@ -32,34 +32,34 @@ We would need to set `threads` based on our CPU. In my case I set to **4**.
 threads = 4
 ```
 
-### Commands and generated files
+### Referee and generated files
 
 `cgarena init` creates:
 
 - `cgarena_config.toml`
-- `play_game.py`
-- `watch_replay.py`
 - `CommandLineInterface.java`
 - `pom_build_section.xml`
 
-The default embedded worker configuration on macOS/Linux is:
+The default embedded worker configuration uses the native CodinGame JAR adapter:
 
 ```toml
-cmd_play_match = "python3 play_game.py {SEED} {REPLAY_PATH} {PLAYERS}"
-cmd_watch_replay = "python3 watch_replay.py {REPLAY_PATH} {REPLAY_DIR} {PORT} {PLAYER_COUNT}"
+[[workers]]
+type = "embedded"
+threads = 4
 cmd_build = "g++ -std=c++20 -x c++ {DIR}/source.txt -o {DIR}/a"
 cmd_run = "./{DIR}/a"
+
+[workers.referee]
+type = "codingame_jar"
+path = "referee/target/referee.jar"
 ```
 
-Install Python 3.9 or newer and Java 17 or newer. On Windows, use the installed Python
-launcher (commonly `py -3`) in both Python commands. The commands are parsed into argument
-lists rather than passed through a shell, so quoted paths containing spaces are preserved.
+Install Java 17 or newer. Patch and build the referee using
+[the referee guide](making_bt_compatible_referee.md), then place the compatible shaded JAR at
+`referee/target/referee.jar`. CG Arena invokes the JAR directly, records each match at a unique
+replay path, extracts the static replay bundle, and serves it under its own HTTP origin.
 
-Patch and build the referee using
-[the referee guide](making_bt_compatible_referee.md), then place the shaded JAR at
-`referee/target/referee.jar`. `play_game.py` records every match at its unique
-`{REPLAY_PATH}`. `watch_replay.py` turns that artifact into a static bundle that CG Arena
-serves under its own HTTP origin.
+Use the [`command` referee adapter](configuration.md#command) for a custom or non-Java referee.
 
 ### Languages that need workspace
 

--- a/docs/example_codingame_setup.md
+++ b/docs/example_codingame_setup.md
@@ -56,8 +56,10 @@ path = "referee/target/referee.jar"
 
 Install Java 17 or newer. Patch and build the referee using
 [the referee guide](making_bt_compatible_referee.md), then place the compatible shaded JAR at
-`referee/target/referee.jar`. CG Arena invokes the JAR directly, records each match at a unique
-replay path, extracts the static replay bundle, and serves it under its own HTTP origin.
+`referee/target/referee.jar`. At startup CG Arena verifies the maintained
+`--cgarena-compat`/`cgarena-referee-v1` contract. It then invokes the JAR directly, records each
+match at a unique replay path, extracts the static replay bundle, and serves it under its own
+HTTP origin.
 
 Use the [`command` referee adapter](configuration.md#command) for a custom or non-Java referee.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,12 +38,15 @@ cd summer-challenge-2025
 
 ## Configuring the arena
 
-The `cgarena init` command generates 2 files in the folder:
+The `cgarena init` command generates the arena configuration plus the maintained Java CLI and
+Maven build patch used to produce a compatible CodinGame referee JAR:
 
-- `cgarena_config.toml` - CG Arena config file with the default config.
-- `play_game.py` - python script for running matches (expects [brutaltester-compatible](making_bt_compatible_referee.md) `referee.jar` in the same folder to work)
+- `cgarena_config.toml`
+- `CommandLineInterface.java`
+- `pom_build_section.xml`
 
-The default config file is documented, so read through it and make any necessary changes. Be sure to restart the arena after modifying the configuration.
+The default configuration runs `referee/target/referee.jar` directly; Python launchers are not
+required. Read the [configuration reference](configuration.md) and restart the arena after changes.
 
 The default config supports c++ out of the box.
 

--- a/docs/making_bt_compatible_referee.md
+++ b/docs/making_bt_compatible_referee.md
@@ -211,6 +211,7 @@ The interface defines the match and replay contract:
 - `-l`: replay JSON output path
 - `-r`: replay JSON input path
 - `-port`: loopback replay renderer port, default `8888`
+- `--cgarena-compat`: print `cgarena-referee-v1` and exit
 
 Match mode writes the JSON artifact requested by `-l`, prints scores and referee input to
 stdout, prints failures to stderr, and exits nonzero on failure. Different processes may use
@@ -237,6 +238,16 @@ mvn package
 The maintained Maven configuration writes `target/referee.jar`. Keep the referee repository
 at `<arena>/referee`, matching the default native adapter path
 `<arena>/referee/target/referee.jar`.
+
+Verify the versioned CG Arena contract before running a match:
+
+```sh
+java --add-opens java.base/java.lang=ALL-UNNAMED \
+  -jar target/referee.jar --cgarena-compat
+```
+
+The command must exit `0` and print `cgarena-referee-v1`. CG Arena performs this probe during
+startup and rejects JARs built without the maintained interface.
 
 Verify a deterministic two-player match outside CG Arena:
 

--- a/docs/making_bt_compatible_referee.md
+++ b/docs/making_bt_compatible_referee.md
@@ -218,8 +218,8 @@ the same seed safely when their `-l` paths differ.
 
 Replay mode reads the complete CodinGame replay JSON, derives participant count from its
 `agents` array, starts `Renderer` on `-port`, then prints its renderer URL and
-`Exposed web server dir: <path>`. `watch_replay.py` consumes the directory line, copies the
-static bundle, terminates the renderer, and reaps it.
+`Exposed web server dir: <path>`. CG Arena copies that static bundle into an isolated replay
+session, terminates the renderer, and reaps it.
 
 The generated `pom_build_section.xml` is the maintained Maven build configuration. Replace
 the referee POM's existing `<build>` section with its contents. Keep the `commons-cli`
@@ -235,7 +235,7 @@ mvn package
 ```
 
 The maintained Maven configuration writes `target/referee.jar`. Keep the referee repository
-at `<arena>/referee`, so the generated Python launchers find
+at `<arena>/referee`, matching the default native adapter path
 `<arena>/referee/target/referee.jar`.
 
 Verify a deterministic two-player match outside CG Arena:
@@ -264,6 +264,6 @@ Read the printed HTTP URL in a browser. Stop the renderer with `Ctrl+C`. Invalid
 or an occupied port is written to stderr and exits nonzero. The replay JSON's `agents` array
 is the source of participant count for two-player and multiplayer artifacts.
 
-The integration is supported on macOS, Linux, and Windows with Python 3.9 or newer, Java 17
-or newer, and Maven for referee builds. Use platform-native path syntax and the installed
-Python launcher (`python3` on macOS/Linux, commonly `py -3` on Windows).
+The integration is supported on macOS, Linux, and Windows with Java 17 or newer and Maven for
+referee builds. Use platform-native path syntax and configure `workers.referee.java` when the
+Java executable is not available as `java` on `PATH`.

--- a/docs/match_attributes_and_filters.md
+++ b/docs/match_attributes_and_filters.md
@@ -14,7 +14,9 @@
 
 ## Match attributes overview
 
-CG Arena [uses](configuration.md#cmd_play_match) `cmd_play_match` command to run matches. That command should write the JSON of specific format to the stdout. One of the properties is `attributes`. CG Arena records those attributes for each match, so that they can be used for match filtering later.
+CG Arena records attributes returned by a custom `command` referee or extracted from tagged
+CodinGame replay errors by the `codingame_jar` referee. These attributes can be used for match
+filtering later.
 
 The attributes can describe 2 kinds of data:
 

--- a/docs/referee_jar_integration_research.md
+++ b/docs/referee_jar_integration_research.md
@@ -13,14 +13,14 @@ The public interface should therefore be a tagged referee configuration with two
 
 That makes the common path one field while retaining the actual variation point. It avoids forcing a Java-specific abstraction onto the 1% of users with a native or custom referee.
 
-## Current CG Arena contract
+## Pre-migration CG Arena contract
 
-CG Arena currently delegates two operations to configured commands:
+Before the native adapter, CG Arena delegated two operations to configured commands:
 
 1. **Match execution.** The embedded worker expands `cmd_run` into one command per bot; expands `{SEED}`, `{REPLAY_PATH}`, and player placeholders in `cmd_play_match`; reserves an owned replay path when requested; and requires a JSON result on stdout. It validates that `ranks`, `errors`, and optional `scores` have exactly one value per participant. [worker.rs:684-841](../src/worker.rs#L684-L841)
 2. **Replay viewing.** `ReplayViewer` allocates an isolated session directory, calls `cmd_watch_replay`, requires a successful exit and `test.html`, then serves the copied static bundle from the arena origin. It has a 30-second timeout and reaps its direct child on timeout. [replay_viewer.rs:133-170](../src/replay_viewer.rs#L133-L170), [replay_viewer.rs:237-293](../src/replay_viewer.rs#L237-L293)
 
-The bundled scripts implement the CodinGame-specific part of these generic contracts:
+The bundled legacy scripts implemented the CodinGame-specific part of these generic contracts:
 
 - `play_game.py` calls Java with one complete player command per `-pN`, a seed, and replay-output path; parses `scores` and `errors` from the resulting replay JSON; turns tagged lines from player stderr into attributes; and prints CG Arena's JSON result. [play_game.py:16-89](../assets/play_game.py#L16-L89)
 - `watch_replay.py` validates the replay JSON and participant count, starts Java replay mode, reads the engine's exposed-directory marker, copies that directory to the session, applies compatibility rewrites, and terminates/reaps Java. [watch_replay.py:48-133](../assets/watch_replay.py#L48-L133)
@@ -73,11 +73,11 @@ The engine renderer is unsuitable as a long-running shared CG Arena replay serve
 - It writes to the fixed directory `${java.io.tmpdir}/codingame` and deletes it before every render. Concurrent renderers race and can destroy each other's source bundle. [Renderer.java:335-365](https://github.com/CodinGame/codingame-game-engine/blob/9e32d14b8845d1a42b6fef61b41f0084d1eaf81c/runner/src/main/java/com/codingame/gameengine/runner/Renderer.java#L335-L365)
 - It logs `Exposed web server dir: …`, then starts an Undertow server bound to `0.0.0.0`, not loopback. [Renderer.java:646-656](https://github.com/CodinGame/codingame-game-engine/blob/9e32d14b8845d1a42b6fef61b41f0084d1eaf81c/runner/src/main/java/com/codingame/gameengine/runner/Renderer.java#L646-L656)
 - A bind failure is downgraded to a warning, so observing a process start or a log line does not prove that the requested port is serving the intended replay. [Renderer.java:875-893](https://github.com/CodinGame/codingame-game-engine/blob/9e32d14b8845d1a42b6fef61b41f0084d1eaf81c/runner/src/main/java/com/codingame/gameengine/runner/Renderer.java#L875-L893)
-- The present wrapper copies the exposed files into the CG Arena-owned session, verifies `test.html`, applies known relative-asset fixes, then terminates Java. [watch_replay.py:29-45](../assets/watch_replay.py#L29-L45), [watch_replay.py:101-121](../assets/watch_replay.py#L101-L121)
+- The legacy wrapper copied the exposed files into the CG Arena-owned session, verified `test.html`, applied known relative-asset fixes, then terminated Java. [watch_replay.py:29-45](../assets/watch_replay.py#L29-L45), [watch_replay.py:101-121](../assets/watch_replay.py#L101-L121)
 
 The native adapter must preserve this disposable-renderer model. Run every renderer with a unique, adapter-owned `java.io.tmpdir`; capture stdout until the exposed directory is announced; copy it to the already-isolated replay session; apply only compatibility rewrites with regression fixtures; then terminate and reap the full renderer process tree. Do not expose the renderer port to the browser or accept the renderer's directory as an artifact path without containment validation.
 
-The current `ReplayViewer` only kills its direct configured child. [replay_viewer.rs:251-271](../src/replay_viewer.rs#L251-L271) A native implementation should improve on the Python wrapper by placing the Java process in its own process group/session where supported, so shutdown cannot leave an Undertow JVM behind.
+The pre-migration `ReplayViewer` only killed its direct configured child. [replay_viewer.rs:251-271](../src/replay_viewer.rs#L251-L271) The native implementation must improve on the Python wrapper by placing the Java process in its own process group/session where supported, so shutdown cannot leave an Undertow JVM behind.
 
 ## Recommended interface
 

--- a/docs/referee_jar_integration_research.md
+++ b/docs/referee_jar_integration_research.md
@@ -1,0 +1,131 @@
+# Native CodinGame referee-JAR integration
+
+## Decision
+
+**Implement this feature, but do not define it as “accept any `referee.jar`.”**
+
+A path-only configuration can remove `play_game.py` and `watch_replay.py` for the normal CodinGame workflow **when the file is an executable, self-contained, CG-Arena-compatible referee JAR**. A generic official referee source checkout or arbitrary JAR does not supply a stable command-line contract, and cannot safely be inferred.
+
+The public interface should therefore be a tagged referee configuration with two adapters:
+
+- `codingame_jar`: a supported built-in adapter that owns Java invocation, match-result extraction, replay capture, static-bundle generation, validation, and cleanup.
+- `command`: the existing `cmd_play_match` / `cmd_watch_replay` contract for custom referees, alternative runtimes, or unsupported JARs.
+
+That makes the common path one field while retaining the actual variation point. It avoids forcing a Java-specific abstraction onto the 1% of users with a native or custom referee.
+
+## Current CG Arena contract
+
+CG Arena currently delegates two operations to configured commands:
+
+1. **Match execution.** The embedded worker expands `cmd_run` into one command per bot; expands `{SEED}`, `{REPLAY_PATH}`, and player placeholders in `cmd_play_match`; reserves an owned replay path when requested; and requires a JSON result on stdout. It validates that `ranks`, `errors`, and optional `scores` have exactly one value per participant. [worker.rs:684-841](../src/worker.rs#L684-L841)
+2. **Replay viewing.** `ReplayViewer` allocates an isolated session directory, calls `cmd_watch_replay`, requires a successful exit and `test.html`, then serves the copied static bundle from the arena origin. It has a 30-second timeout and reaps its direct child on timeout. [replay_viewer.rs:133-170](../src/replay_viewer.rs#L133-L170), [replay_viewer.rs:237-293](../src/replay_viewer.rs#L237-L293)
+
+The bundled scripts implement the CodinGame-specific part of these generic contracts:
+
+- `play_game.py` calls Java with one complete player command per `-pN`, a seed, and replay-output path; parses `scores` and `errors` from the resulting replay JSON; turns tagged lines from player stderr into attributes; and prints CG Arena's JSON result. [play_game.py:16-89](../assets/play_game.py#L16-L89)
+- `watch_replay.py` validates the replay JSON and participant count, starts Java replay mode, reads the engine's exposed-directory marker, copies that directory to the session, applies compatibility rewrites, and terminates/reaps Java. [watch_replay.py:48-133](../assets/watch_replay.py#L48-L133)
+
+The scripts are not merely launchers. Moving to Rust must preserve their artifact/result conversion and cleanup behavior; otherwise match ranking and replay UI regress.
+
+## What an upstream CodinGame referee provides
+
+### The source repository is not an executable JAR contract
+
+The supplied official Summer Challenge 2025 source at commit [`82bbb1b`](https://github.com/CodinGame/SummerChallenge2025-SoakOverflow/tree/82bbb1b383f7cd9ec87e5d2c3f95daf31dde5cd2) declares game-engine libraries but no build plugins, main class, or shaded artifact in its committed POM. [upstream `pom.xml`](https://github.com/CodinGame/SummerChallenge2025-SoakOverflow/blob/82bbb1b383f7cd9ec87e5d2c3f95daf31dde5cd2/pom.xml)
+
+The local working copy contains uncommitted changes: a build section, a `commons-cli` dependency, and an untracked `CommandLineInterface.java`. Those are precisely the additions that create the runnable JAR and its CLI. This is strong evidence that a download/build of the official source **as-is** is not sufficient for CG Arena.
+
+The built local JAR's manifest names `com.codingame.gameengine.runner.CommandLineInterface` as `Main-Class`, but this verifies only that the locally patched/shaded output is executable—not that all official referees are. [`META-INF/MANIFEST.MF`](file:///Users/yevhenkazmin/Projects/cg/referees/SummerChallenge2025-SoakOverflow/target/summer-challenge-2025-super-soaker-1.0-SNAPSHOT.jar:META-INF/MANIFEST.MF)
+
+**Observed experiment (2026-09-04).** Running that locally patched JAR with `java --add-opens java.base/java.lang=ALL-UNNAMED -jar … -p1 "python3 config/Boss.py" -p2 "python3 config/Boss.py" -seed 1 -l /tmp/cgarena-referee-jar-research-1.json` exited successfully in 4.67 seconds, printed one score per player, and wrote the expected replay JSON. The supplied bot fixture failed with `NameError`, so both scores were `-1`; the artifact still contained `errors`, `outputs`, `summaries`, `views`, and `agents`. This proves the *patched* CLI/JAR path is viable and that replay JSON carries the fields the native adapter needs. It does not validate an unmodified upstream JAR.
+
+### CG Arena's maintained CLI is the needed compatibility layer
+
+CG Arena currently supplies a replacement `CommandLineInterface` for referee sources. It accepts:
+
+- `-p1` through `-p8`: each complete bot command;
+- `-seed`: signed Java `long` seed;
+- `-league`: engine league level, default `19`;
+- `-l`: replay JSON output;
+- `-r`: replay JSON input;
+- `-port`: replay-renderer port.
+
+[CommandLineInterface.java:20-49](../assets/CommandLineInterface.java#L20-L49)
+
+In match mode it constructs `MultiplayerGameRunner`, sets the seed and league, adds agents, invokes engine-private methods reflectively, writes the engine JSON result to `-l`, and prints scores plus referee input. [CommandLineInterface.java:75-123](../assets/CommandLineInterface.java#L75-L123)
+
+In replay mode it derives player count from `agents` in the persisted JSON and starts the engine renderer on `-port`. [CommandLineInterface.java:61-73](../assets/CommandLineInterface.java#L61-L73)
+
+This is the functional contract CG Arena can support. It is version-sensitive because it relies on engine private fields and methods (`initialize`, `runAgents`, `getJSONResult`, `players`, and `process`). The same symbols are private in the current engine source at [`9e32d14`](https://github.com/CodinGame/codingame-game-engine/tree/9e32d14b8845d1a42b6fef61b41f0084d1eaf81c). [GameRunner.java](https://github.com/CodinGame/codingame-game-engine/blob/9e32d14b8845d1a42b6fef61b41f0084d1eaf81c/runner/src/main/java/com/codingame/gameengine/runner/GameRunner.java#L55-L68) and [the private match methods](https://github.com/CodinGame/codingame-game-engine/blob/9e32d14b8845d1a42b6fef61b41f0084d1eaf81c/runner/src/main/java/com/codingame/gameengine/runner/GameRunner.java#L114-L219).
+
+### Java and process behavior
+
+The scripts invoke `java --add-opens java.base/java.lang=ALL-UNNAMED -jar …`. [play_game.py:23-40](../assets/play_game.py#L23-L40), [watch_replay.py:62-92](../assets/watch_replay.py#L62-L92) The flag exists because the runner's reflection and process cleanup are sensitive to modern Java access restrictions; it must remain a default of the built-in adapter, with an advanced override only if evidence shows a game needs a different JVM invocation.
+
+The example referee requests Java 17. [example `pom.xml`:9-14](file:///Users/yevhenkazmin/Projects/cg/referees/SummerChallenge2025-SoakOverflow/pom.xml#L9-L14) CG Arena should require a Java runtime compatible with the JAR's bytecode rather than hard-code a Java version.
+
+The runner executes each player command through `Runtime.exec`; player command tokenization is therefore governed by Java rather than a shell. [MultiplayerGameRunner.java:88-97](https://github.com/CodinGame/codingame-game-engine/blob/9e32d14b8845d1a42b6fef61b41f0084d1eaf81c/runner/src/main/java/com/codingame/gameengine/runner/MultiplayerGameRunner.java#L88-L97) CG Arena must pass every expanded `cmd_run` as one `-pN` argument; it must not split or shell-wrap the player command.
+
+## Replay risks that native integration must explicitly solve
+
+The engine renderer is unsuitable as a long-running shared CG Arena replay server:
+
+- It writes to the fixed directory `${java.io.tmpdir}/codingame` and deletes it before every render. Concurrent renderers race and can destroy each other's source bundle. [Renderer.java:335-365](https://github.com/CodinGame/codingame-game-engine/blob/9e32d14b8845d1a42b6fef61b41f0084d1eaf81c/runner/src/main/java/com/codingame/gameengine/runner/Renderer.java#L335-L365)
+- It logs `Exposed web server dir: …`, then starts an Undertow server bound to `0.0.0.0`, not loopback. [Renderer.java:646-656](https://github.com/CodinGame/codingame-game-engine/blob/9e32d14b8845d1a42b6fef61b41f0084d1eaf81c/runner/src/main/java/com/codingame/gameengine/runner/Renderer.java#L646-L656)
+- A bind failure is downgraded to a warning, so observing a process start or a log line does not prove that the requested port is serving the intended replay. [Renderer.java:875-893](https://github.com/CodinGame/codingame-game-engine/blob/9e32d14b8845d1a42b6fef61b41f0084d1eaf81c/runner/src/main/java/com/codingame/gameengine/runner/Renderer.java#L875-L893)
+- The present wrapper copies the exposed files into the CG Arena-owned session, verifies `test.html`, applies known relative-asset fixes, then terminates Java. [watch_replay.py:29-45](../assets/watch_replay.py#L29-L45), [watch_replay.py:101-121](../assets/watch_replay.py#L101-L121)
+
+The native adapter must preserve this disposable-renderer model. Run every renderer with a unique, adapter-owned `java.io.tmpdir`; capture stdout until the exposed directory is announced; copy it to the already-isolated replay session; apply only compatibility rewrites with regression fixtures; then terminate and reap the full renderer process tree. Do not expose the renderer port to the browser or accept the renderer's directory as an artifact path without containment validation.
+
+The current `ReplayViewer` only kills its direct configured child. [replay_viewer.rs:251-271](../src/replay_viewer.rs#L251-L271) A native implementation should improve on the Python wrapper by placing the Java process in its own process group/session where supported, so shutdown cannot leave an Undertow JVM behind.
+
+## Recommended interface
+
+Use an exclusive `referee` value in each embedded worker; do not put `referee_jar` beside the existing command fields. Two adjacent sources of truth would make precedence, replay ownership, and error semantics ambiguous.
+
+```toml
+[[workers]]
+type = "embedded"
+threads = 4
+cmd_build = "g++ -std=c++20 -x c++ {DIR}/source.txt -o {DIR}/a"
+cmd_run = "./{DIR}/a"
+
+[workers.referee]
+type = "codingame_jar"
+path = "referee/target/referee.jar"
+# Optional. Defaults to `java` and `19`.
+# java = "java"
+# league = 19
+```
+
+For the compatible custom path:
+
+```toml
+[workers.referee]
+type = "command"
+play_match = "my-referee {SEED} {REPLAY_PATH} {PLAYERS}"
+watch_replay = "my-renderer {REPLAY_PATH} {REPLAY_DIR} {PORT} {PLAYER_COUNT}"
+```
+
+Clean cutover: migrate the default configuration and generated setup to `codingame_jar`; remove the generated Python scripts from the default path; retain the documented `command` adapter as the sole migration target for non-Java/custom referees. Existing configurations can be migrated in the same release or supported temporarily through an explicit config-format migration. Do not silently prioritize one set of fields over another.
+
+The external interface remains small:
+
+- one selected referee adapter;
+- `cmd_run` yields an opaque player command per participant;
+- match result is CG Arena's existing `ranks`, `errors`, optional `scores`, and attributes;
+- replay result is the existing owned static bundle with `test.html`.
+
+The adapter hides all Java arguments, replay JSON parsing, renderer output parsing, copy/normalization, cancellation, and JAR validation. That is a deep module: callers learn one configuration form, while the engine-specific behavior stays local and testable.
+
+## Implementation plan
+
+1. **Lock the supported-JAR definition.** Call it `CG-Arena-compatible CodinGame referee JAR`: self-contained `java -jar` entrypoint implementing the current `-pN/-seed/-l/-r/-port` contract. Update the referee patch/build guide to produce that exact artifact. Reject missing, non-regular, or incompatible JARs at arena startup with a diagnostic that names the required contract. Do not claim support for an unmodified official JAR.
+2. **Introduce a `RefereeAdapter` seam.** Configuration selects exactly one adapter. Implement `CommandRefereeAdapter` by moving the present command fields intact, then implement `CodingameJarRefereeAdapter`. Both produce the existing match output and static replay bundle contracts; worker, arena, database, and API need no domain-model change.
+3. **Port match behavior with contract tests.** Invoke Java directly with argument vectors; pass each complete bot command as one `-pN`; create the replay through `ReplayArtifacts`; parse replay `scores`, player errors, and `[TDATA]/[PDATA]` attributes identically to `play_game.py`; calculate ranks using the existing wrapper rule; report actionable stderr without corrupting the result channel.
+4. **Port replay behavior safely.** Give each invocation a unique JVM temp directory and ephemeral loopback port; validate the JSON `agents` count against the persisted participant count; wait for and validate the exposed path; copy it into the session; apply only tested asset rewrites; terminate and reap Java in success, error, timeout, and cancellation paths.
+5. **Migrate defaults and verify real artifacts.** Replace default generated Python commands with the JAR adapter and update setup/configuration docs. Keep the command adapter example for custom implementations. Add tests for config exclusivity, Java argument construction with spaces, replay score/error/attribute conversion, invalid artifacts, concurrent renderer isolation, timeout cleanup, and a fixture JAR covering a real match plus replay bundle.
+
+## Bottom line
+
+The feature is high-leverage: it removes Python and two editable scripts from the dominant setup, centralizes a fragile CodinGame integration, and gives CG Arena ownership of artifacts and process cleanup. The safe product promise is **“supply a supported CG-Arena-compatible referee JAR”**, not **“supply any official JAR.”** The latter would be misleading because upstream referee repositories and JARs do not consistently provide the required executable CLI, artifact behavior, or renderer semantics.

--- a/docs/referee_jar_integration_research.md
+++ b/docs/referee_jar_integration_research.md
@@ -1,8 +1,8 @@
 # Native CodinGame referee-JAR integration
 
-## Decision
+## Research conclusion
 
-**Implement this feature, but do not define it as “accept any `referee.jar`.”**
+This note records non-normative implementation evidence for specification issue #21. The supported product contract is: **implement this feature, but do not define it as “accept any `referee.jar`.”**
 
 A path-only configuration can remove `play_game.py` and `watch_replay.py` for the normal CodinGame workflow **when the file is an executable, self-contained, CG-Arena-compatible referee JAR**. A generic official referee source checkout or arbitrary JAR does not supply a stable command-line contract, and cannot safely be inferred.
 

--- a/src/api/errors.rs
+++ b/src/api/errors.rs
@@ -36,7 +36,7 @@ impl ApiError {
                     StatusCode::UNPROCESSABLE_ENTITY
                 }
                 crate::replay_viewer::ReplayError::StartupFailed(_) => StatusCode::BAD_GATEWAY,
-                crate::replay_viewer::ReplayError::StartupTimeout => StatusCode::GATEWAY_TIMEOUT,
+                crate::replay_viewer::ReplayError::StartupTimeout(_) => StatusCode::GATEWAY_TIMEOUT,
                 crate::replay_viewer::ReplayError::InvalidCommand(_)
                 | crate::replay_viewer::ReplayError::Internal(_) => {
                     StatusCode::INTERNAL_SERVER_ERROR
@@ -58,7 +58,7 @@ impl ApiError {
                 crate::replay_viewer::ReplayError::Unavailable => "replay_unavailable",
                 crate::replay_viewer::ReplayError::InvalidArtifact(_) => "invalid_replay",
                 crate::replay_viewer::ReplayError::StartupFailed(_) => "replay_start_failed",
-                crate::replay_viewer::ReplayError::StartupTimeout => "replay_start_timeout",
+                crate::replay_viewer::ReplayError::StartupTimeout(_) => "replay_start_timeout",
                 crate::replay_viewer::ReplayError::InvalidCommand(_)
                 | crate::replay_viewer::ReplayError::Internal(_) => "internal_error",
             },

--- a/src/arena_server.rs
+++ b/src/arena_server.rs
@@ -75,7 +75,7 @@ pub async fn start(arena_path: &Path) -> anyhow::Result<()> {
     let replay_viewer = ReplayViewer::new(
         pool.clone(),
         arena_path.to_owned(),
-        cfg.cmd_watch_replay.clone(),
+        cfg.referee.clone(),
         token.clone(),
     );
 
@@ -188,17 +188,6 @@ static DEFAULT_FILES: &[(&str, &str)] = &[
         )),
     ),
     (
-        "play_game.py",
-        include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/play_game.py")),
-    ),
-    (
-        "watch_replay.py",
-        include_str!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/assets/watch_replay.py"
-        )),
-    ),
-    (
         "CommandLineInterface.java",
         include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
@@ -268,8 +257,8 @@ mod test {
         let path = dir.path().join("test");
         init(&path).unwrap();
         assert!(path.join("cgarena_config.toml").exists());
-        assert!(path.join("play_game.py").exists());
-        assert!(path.join("watch_replay.py").exists());
+        assert!(!path.join("play_game.py").exists());
+        assert!(!path.join("watch_replay.py").exists());
         assert!(path.join("CommandLineInterface.java").exists());
         assert!(path.join("pom_build_section.xml").exists());
     }

--- a/src/arena_server.rs
+++ b/src/arena_server.rs
@@ -289,7 +289,9 @@ mod test {
     async fn codingame_referee_compatibility_is_validated_relative_to_arena() {
         use std::os::unix::fs::PermissionsExt;
 
-        let arena = tempfile::tempdir().unwrap();
+        let current_directory = std::env::current_dir().unwrap();
+        let arena = tempfile::tempdir_in(&current_directory).unwrap();
+        let relative_arena = arena.path().strip_prefix(&current_directory).unwrap();
         let jar = arena.path().join("referee/target/referee.jar");
         std::fs::create_dir_all(jar.parent().unwrap()).unwrap();
         std::fs::write(&jar, b"fixture").unwrap();
@@ -309,18 +311,18 @@ mod test {
         };
         referee.java = Some(java.to_string_lossy().to_string());
 
-        validate_referees(arena.path(), &config.workers)
+        validate_referees(relative_arena, &config.workers)
             .await
             .unwrap();
 
         std::fs::write(&java, "#!/bin/sh\necho incompatible\nexit 1\n").unwrap();
-        let error = validate_referees(arena.path(), &config.workers)
+        let error = validate_referees(relative_arena, &config.workers)
             .await
             .unwrap_err();
         assert!(error.to_string().contains("unsupported referee JAR"));
 
         std::fs::remove_file(&jar).unwrap();
-        let error = validate_referees(arena.path(), &config.workers)
+        let error = validate_referees(relative_arena, &config.workers)
             .await
             .unwrap_err();
         assert!(error.to_string().contains("referee.jar"));

--- a/src/arena_server.rs
+++ b/src/arena_server.rs
@@ -1,6 +1,7 @@
 use crate::arena_handle::ArenaHandle;
 use crate::cg_referee::CgReferee;
-use crate::config::{Config, RefereeConfig, WorkerConfig};
+use crate::config::{Config, WorkerConfig};
+use crate::referee_adapter::RefereeAdapter;
 use crate::replay_viewer::ReplayViewer;
 use crate::{api, arena, db, worker};
 use anyhow::{bail, Context};
@@ -43,7 +44,7 @@ pub async fn start(arena_path: &Path) -> anyhow::Result<()> {
             cg_referee.ensure_initialized()?;
         }
     }
-    validate_referee_paths(arena_path, &config.workers)?;
+    validate_referees(arena_path, &config.workers).await?;
 
     let pool = db::connect(arena_path)
         .await
@@ -180,24 +181,12 @@ pub async fn start(arena_path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn validate_referee_paths(arena_path: &Path, workers: &[WorkerConfig]) -> anyhow::Result<()> {
+async fn validate_referees(arena_path: &Path, workers: &[WorkerConfig]) -> anyhow::Result<()> {
     for worker in workers {
         let WorkerConfig::Embedded(worker) = worker;
-        if let RefereeConfig::CodingameJar(referee) = &worker.referee {
-            let path = arena_path.join(&referee.path);
-            let metadata = std::fs::metadata(&path).with_context(|| {
-                format!("Cannot read codingame referee JAR at {}", path.display())
-            })?;
-            if !metadata.is_file() {
-                bail!(
-                    "Codingame referee JAR must be a regular file: {}",
-                    path.display()
-                );
-            }
-            std::fs::File::open(&path).with_context(|| {
-                format!("Cannot read codingame referee JAR at {}", path.display())
-            })?;
-        }
+        RefereeAdapter::from(&worker.referee)
+            .validate_startup(arena_path)
+            .await?;
     }
     Ok(())
 }
@@ -295,18 +284,45 @@ mod test {
         assert!(path.join("cgarena_config.toml").exists());
     }
 
-    #[test]
-    fn codingame_referee_path_is_validated_relative_to_arena() {
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn codingame_referee_compatibility_is_validated_relative_to_arena() {
+        use std::os::unix::fs::PermissionsExt;
+
         let arena = tempfile::tempdir().unwrap();
         let jar = arena.path().join("referee/target/referee.jar");
         std::fs::create_dir_all(jar.parent().unwrap()).unwrap();
         std::fs::write(&jar, b"fixture").unwrap();
-        let config = Config::default();
+        let java = arena.path().join("fake-java.sh");
+        std::fs::write(
+            &java,
+            "#!/bin/sh\ntest \"$5\" = --cgarena-compat\nprintf '%s\\n' cgarena-referee-v1\n",
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&java).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&java, permissions).unwrap();
+        let mut config = Config::default();
+        let WorkerConfig::Embedded(worker) = &mut config.workers[0];
+        let crate::config::RefereeConfig::CodingameJar(referee) = &mut worker.referee else {
+            panic!("default worker must use codingame_jar");
+        };
+        referee.java = Some(java.to_string_lossy().to_string());
 
-        validate_referee_paths(arena.path(), &config.workers).unwrap();
+        validate_referees(arena.path(), &config.workers)
+            .await
+            .unwrap();
+
+        std::fs::write(&java, "#!/bin/sh\necho incompatible\nexit 1\n").unwrap();
+        let error = validate_referees(arena.path(), &config.workers)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("unsupported referee JAR"));
 
         std::fs::remove_file(&jar).unwrap();
-        let error = validate_referee_paths(arena.path(), &config.workers).unwrap_err();
+        let error = validate_referees(arena.path(), &config.workers)
+            .await
+            .unwrap_err();
         assert!(error.to_string().contains("referee.jar"));
     }
 }

--- a/src/arena_server.rs
+++ b/src/arena_server.rs
@@ -1,6 +1,6 @@
 use crate::arena_handle::ArenaHandle;
 use crate::cg_referee::CgReferee;
-use crate::config::{Config, WorkerConfig};
+use crate::config::{Config, RefereeConfig, WorkerConfig};
 use crate::replay_viewer::ReplayViewer;
 use crate::{api, arena, db, worker};
 use anyhow::{bail, Context};
@@ -43,6 +43,7 @@ pub async fn start(arena_path: &Path) -> anyhow::Result<()> {
             cg_referee.ensure_initialized()?;
         }
     }
+    validate_referee_paths(arena_path, &config.workers)?;
 
     let pool = db::connect(arena_path)
         .await
@@ -179,6 +180,28 @@ pub async fn start(arena_path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn validate_referee_paths(arena_path: &Path, workers: &[WorkerConfig]) -> anyhow::Result<()> {
+    for worker in workers {
+        let WorkerConfig::Embedded(worker) = worker;
+        if let RefereeConfig::CodingameJar(referee) = &worker.referee {
+            let path = arena_path.join(&referee.path);
+            let metadata = std::fs::metadata(&path).with_context(|| {
+                format!("Cannot read codingame referee JAR at {}", path.display())
+            })?;
+            if !metadata.is_file() {
+                bail!(
+                    "Codingame referee JAR must be a regular file: {}",
+                    path.display()
+                );
+            }
+            std::fs::File::open(&path).with_context(|| {
+                format!("Cannot read codingame referee JAR at {}", path.display())
+            })?;
+        }
+    }
+    Ok(())
+}
+
 static DEFAULT_FILES: &[(&str, &str)] = &[
     (
         "cgarena_config.toml",
@@ -270,5 +293,20 @@ mod test {
         std::fs::create_dir(&path).unwrap();
         init(&path).unwrap();
         assert!(path.join("cgarena_config.toml").exists());
+    }
+
+    #[test]
+    fn codingame_referee_path_is_validated_relative_to_arena() {
+        let arena = tempfile::tempdir().unwrap();
+        let jar = arena.path().join("referee/target/referee.jar");
+        std::fs::create_dir_all(jar.parent().unwrap()).unwrap();
+        std::fs::write(&jar, b"fixture").unwrap();
+        let config = Config::default();
+
+        validate_referee_paths(arena.path(), &config.workers).unwrap();
+
+        std::fs::remove_file(&jar).unwrap();
+        let error = validate_referee_paths(arena.path(), &config.workers).unwrap_err();
+        assert!(error.to_string().contains("referee.jar"));
     }
 }

--- a/src/arena_tests.rs
+++ b/src/arena_tests.rs
@@ -48,6 +48,7 @@ async fn create_test_arena(mut config: Config, play_output: Option<&str>) -> Tes
         crate::config::RefereeConfig::Command(crate::config::CommandRefereeConfig {
             play_match: format!("sh {}", shell_words::quote(&play_script.to_string_lossy())),
             watch_replay: "true".to_string(),
+            legacy: false,
         });
 
     let StartedWorker { worker, supervisor } =

--- a/src/arena_tests.rs
+++ b/src/arena_tests.rs
@@ -44,8 +44,11 @@ async fn create_test_arena(mut config: Config, play_output: Option<&str>) -> Tes
     };
     worker_config.cmd_build = "sh -c true".to_string();
     worker_config.cmd_run = "true".to_string();
-    worker_config.cmd_play_match =
-        format!("sh {}", shell_words::quote(&play_script.to_string_lossy()));
+    worker_config.referee =
+        crate::config::RefereeConfig::Command(crate::config::CommandRefereeConfig {
+            play_match: format!("sh {}", shell_words::quote(&play_script.to_string_lossy())),
+            watch_replay: "true".to_string(),
+        });
 
     let StartedWorker { worker, supervisor } =
         worker::start_embedded_worker(arena_path.path(), worker_config.clone()).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,6 +80,7 @@ impl<'de> Deserialize<'de> for EmbeddedWorkerConfig {
                 RefereeConfig::Command(CommandRefereeConfig {
                     play_match,
                     watch_replay,
+                    legacy: true,
                 })
             }
             (Some(_), _, _) => {
@@ -120,6 +121,8 @@ pub struct CodingameJarRefereeConfig {
 pub struct CommandRefereeConfig {
     pub play_match: String,
     pub watch_replay: String,
+    #[serde(skip)]
+    pub(crate) legacy: bool,
 }
 
 #[derive(Serialize, Deserialize, Default)]
@@ -202,11 +205,36 @@ impl Config {
                     if config.watch_replay.split_ascii_whitespace().count() == 0 {
                         bail!("command referee watch_replay must not be blank");
                     }
+                    if !config.legacy {
+                        require_placeholder(&config.play_match, "{SEED}", "play_match")?;
+                        require_placeholder(&config.play_match, "{REPLAY_PATH}", "play_match")?;
+                        if !config.play_match.contains("{PLAYERS}") {
+                            for player in 1..=self.game.max_players {
+                                require_placeholder(
+                                    &config.play_match,
+                                    &format!("{{P{player}}}"),
+                                    "play_match",
+                                )?;
+                            }
+                        }
+                        for placeholder in
+                            ["{REPLAY_PATH}", "{REPLAY_DIR}", "{PORT}", "{PLAYER_COUNT}"]
+                        {
+                            require_placeholder(&config.watch_replay, placeholder, "watch_replay")?;
+                        }
+                    }
                 }
             }
         }
         Ok(())
     }
+}
+
+fn require_placeholder(template: &str, placeholder: &str, field: &str) -> anyhow::Result<()> {
+    if !template.contains(placeholder) {
+        bail!("command referee {field} must contain {placeholder}");
+    }
+    Ok(())
 }
 
 const CONFIG_FILE_NAME: &str = "cgarena_config.toml";
@@ -222,7 +250,8 @@ mod test {
 
     #[test]
     fn default_config_is_valid() {
-        let _: Config = toml::from_str(DEFAULT_CONFIG_CONTENT).expect("to be a valid config");
+        let config: Config = toml::from_str(DEFAULT_CONFIG_CONTENT).expect("to be a valid config");
+        config.validate().expect("default config should validate");
     }
 
     #[test]
@@ -260,6 +289,42 @@ watch_replay = "new""#,
         };
 
         assert!(error.to_string().contains("cannot be combined"));
+    }
+
+    #[test]
+    fn tagged_command_referee_requires_complete_templates() {
+        let mut config = Config::default();
+        let [WorkerConfig::Embedded(worker)] = config.workers.as_mut_slice() else {
+            panic!("default config must contain one embedded worker");
+        };
+        worker.referee = RefereeConfig::Command(CommandRefereeConfig {
+            play_match: "runner {SEED} {REPLAY_PATH} {PLAYERS}".to_string(),
+            watch_replay: "renderer {REPLAY_PATH}".to_string(),
+            legacy: false,
+        });
+
+        let error = config.validate().unwrap_err();
+
+        assert!(error.to_string().contains("{REPLAY_DIR}"));
+    }
+
+    #[test]
+    fn migrated_legacy_command_templates_keep_previous_validation_rules() {
+        let legacy: EmbeddedWorkerConfig = toml::from_str(
+            r#"threads = 1
+cmd_play_match = "runner"
+cmd_watch_replay = "renderer"
+cmd_build = "build"
+cmd_run = "run""#,
+        )
+        .unwrap();
+        let mut config = Config::default();
+        let [WorkerConfig::Embedded(worker)] = config.workers.as_mut_slice() else {
+            panic!("default config must contain one embedded worker");
+        };
+        worker.referee = legacy.referee;
+
+        config.validate().unwrap();
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -206,12 +206,16 @@ impl Config {
                         bail!("command referee watch_replay must not be blank");
                     }
                     if !config.legacy {
-                        require_placeholder(&config.play_match, "{SEED}", "play_match")?;
-                        require_placeholder(&config.play_match, "{REPLAY_PATH}", "play_match")?;
-                        if !config.play_match.contains("{PLAYERS}") {
+                        let play_match = shell_words::split(&config.play_match)
+                            .context("command referee play_match has invalid quoting")?;
+                        let watch_replay = shell_words::split(&config.watch_replay)
+                            .context("command referee watch_replay has invalid quoting")?;
+                        require_placeholder(&play_match, "{SEED}", "play_match")?;
+                        require_placeholder(&play_match, "{REPLAY_PATH}", "play_match")?;
+                        if !play_match.iter().any(|part| part == "{PLAYERS}") {
                             for player in 1..=self.game.max_players {
                                 require_placeholder(
-                                    &config.play_match,
+                                    &play_match,
                                     &format!("{{P{player}}}"),
                                     "play_match",
                                 )?;
@@ -220,7 +224,7 @@ impl Config {
                         for placeholder in
                             ["{REPLAY_PATH}", "{REPLAY_DIR}", "{PORT}", "{PLAYER_COUNT}"]
                         {
-                            require_placeholder(&config.watch_replay, placeholder, "watch_replay")?;
+                            require_placeholder(&watch_replay, placeholder, "watch_replay")?;
                         }
                     }
                 }
@@ -230,8 +234,8 @@ impl Config {
     }
 }
 
-fn require_placeholder(template: &str, placeholder: &str, field: &str) -> anyhow::Result<()> {
-    if !template.contains(placeholder) {
+fn require_placeholder(template: &[String], placeholder: &str, field: &str) -> anyhow::Result<()> {
+    if !template.iter().any(|part| part == placeholder) {
         bail!("command referee {field} must contain {placeholder}");
     }
     Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,10 +56,29 @@ pub enum WorkerConfig {
 #[derive(Serialize, Deserialize, Clone)]
 pub struct EmbeddedWorkerConfig {
     pub threads: u8,
-    pub cmd_play_match: String,
-    pub cmd_watch_replay: String,
+    pub referee: RefereeConfig,
     pub cmd_build: String,
     pub cmd_run: String,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RefereeConfig {
+    CodingameJar(CodingameJarRefereeConfig),
+    Command(CommandRefereeConfig),
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct CodingameJarRefereeConfig {
+    pub path: String,
+    pub java: Option<String>,
+    pub league: Option<u8>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct CommandRefereeConfig {
+    pub play_match: String,
+    pub watch_replay: String,
 }
 
 #[derive(Serialize, Deserialize, Default)]
@@ -115,11 +134,33 @@ impl Config {
             if config.cmd_run.split_ascii_whitespace().count() == 0 {
                 bail!("cmd_run must not be blank");
             }
-            if config.cmd_play_match.split_ascii_whitespace().count() == 0 {
-                bail!("cmd_play_match must not be blank");
-            }
-            if config.cmd_watch_replay.split_ascii_whitespace().count() == 0 {
-                bail!("cmd_watch_replay must not be blank");
+            match &config.referee {
+                RefereeConfig::CodingameJar(config) => {
+                    if config.path.trim().is_empty() {
+                        bail!("codingame_jar referee path must not be blank");
+                    }
+                    if config
+                        .java
+                        .as_deref()
+                        .is_some_and(|java| java.trim().is_empty())
+                    {
+                        bail!("codingame_jar referee java must not be blank");
+                    }
+                    if config
+                        .league
+                        .is_some_and(|league| league == 0 || league >= 20)
+                    {
+                        bail!("codingame_jar referee league must be between 1 and 19");
+                    }
+                }
+                RefereeConfig::Command(config) => {
+                    if config.play_match.split_ascii_whitespace().count() == 0 {
+                        bail!("command referee play_match must not be blank");
+                    }
+                    if config.watch_replay.split_ascii_whitespace().count() == 0 {
+                        bail!("command referee watch_replay must not be blank");
+                    }
+                }
             }
         }
         Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,12 +53,53 @@ pub enum WorkerConfig {
     // Remote
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Clone)]
 pub struct EmbeddedWorkerConfig {
     pub threads: u8,
     pub referee: RefereeConfig,
     pub cmd_build: String,
     pub cmd_run: String,
+}
+
+#[derive(Deserialize)]
+struct RawEmbeddedWorkerConfig {
+    threads: u8,
+    referee: Option<RefereeConfig>,
+    cmd_play_match: Option<String>,
+    cmd_watch_replay: Option<String>,
+    cmd_build: String,
+    cmd_run: String,
+}
+
+impl<'de> Deserialize<'de> for EmbeddedWorkerConfig {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = RawEmbeddedWorkerConfig::deserialize(deserializer)?;
+        let referee = match (raw.referee, raw.cmd_play_match, raw.cmd_watch_replay) {
+            (Some(referee), None, None) => referee,
+            (None, Some(play_match), Some(watch_replay)) => {
+                RefereeConfig::Command(CommandRefereeConfig {
+                    play_match,
+                    watch_replay,
+                })
+            }
+            (Some(_), _, _) => {
+                return Err(serde::de::Error::custom(
+                    "referee cannot be combined with legacy cmd_play_match or cmd_watch_replay",
+                ))
+            }
+            (None, _, _) => {
+                return Err(serde::de::Error::custom(
+                    "configure referee or both legacy cmd_play_match and cmd_watch_replay",
+                ))
+            }
+        };
+        Ok(Self {
+            threads: raw.threads,
+            referee,
+            cmd_build: raw.cmd_build,
+            cmd_run: raw.cmd_run,
+        })
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -153,6 +194,7 @@ impl Config {
                         bail!("codingame_jar referee league must be between 1 and 19");
                     }
                 }
+
                 RefereeConfig::Command(config) => {
                     if config.play_match.split_ascii_whitespace().count() == 0 {
                         bail!("command referee play_match must not be blank");
@@ -181,6 +223,43 @@ mod test {
     #[test]
     fn default_config_is_valid() {
         let _: Config = toml::from_str(DEFAULT_CONFIG_CONTENT).expect("to be a valid config");
+    }
+
+    #[test]
+    fn legacy_match_commands_migrate_to_command_referee() {
+        let config: EmbeddedWorkerConfig = toml::from_str(
+            r#"threads = 1
+cmd_play_match = "runner {SEED} {PLAYERS}"
+cmd_watch_replay = "renderer {REPLAY_PATH} {REPLAY_DIR} {PORT} {PLAYER_COUNT}"
+cmd_build = "build"
+cmd_run = "run""#,
+        )
+        .unwrap();
+        let RefereeConfig::Command(referee) = config.referee else {
+            panic!("legacy command fields must migrate");
+        };
+        assert_eq!(referee.play_match, "runner {SEED} {PLAYERS}");
+    }
+
+    #[test]
+    fn mixed_legacy_and_tagged_referee_configuration_is_rejected() {
+        let result = toml::from_str::<EmbeddedWorkerConfig>(
+            r#"threads = 1
+cmd_play_match = "legacy"
+cmd_watch_replay = "legacy"
+cmd_build = "build"
+cmd_run = "run"
+
+[referee]
+type = "command"
+play_match = "new"
+watch_replay = "new""#,
+        );
+        let Err(error) = result else {
+            panic!("mixed referee configuration must be rejected");
+        };
+
+        assert!(error.to_string().contains("cannot be combined"));
     }
 
     #[test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -374,3 +374,47 @@ pub async fn fetch_leaderboards(pool: &SqlitePool) -> anyhow::Result<Vec<Leaderb
         .collect();
     Ok(leaderboards)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::borrow::Cow;
+
+    #[tokio::test]
+    async fn current_migrations_upgrade_pre_replay_database() {
+        let pool = in_memory().await.unwrap();
+        let current = sqlx::migrate!();
+        let historical = sqlx::migrate::Migrator {
+            migrations: Cow::Owned(
+                current
+                    .iter()
+                    .filter(|migration| migration.version < 20260901160000)
+                    .cloned()
+                    .collect(),
+            ),
+            ignore_missing: false,
+            locking: true,
+            no_tx: false,
+        };
+        historical.run(&pool).await.unwrap();
+        sqlx::query("INSERT INTO matches (seed, participant_cnt) VALUES (7, 2)")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        current.run(&pool).await.unwrap();
+
+        let replay_columns: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM pragma_table_info('matches') WHERE name = 'replay_path'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let old_matches: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM matches WHERE seed = 7")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(replay_columns, 1);
+        assert_eq!(old_matches, 1);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod domain;
 mod match_retrieval;
 mod matchmaking;
 mod ranking;
+mod referee_adapter;
 mod replay_artifact;
 mod replay_viewer;
 mod worker;

--- a/src/referee_adapter.rs
+++ b/src/referee_adapter.rs
@@ -188,7 +188,9 @@ impl RefereeAdapter<'_> {
         let Self::CodingameJar(config) = self else {
             return Ok(());
         };
-        let jar_path = resolve_path(arena_path, &config.path);
+        let configured_path = resolve_path(arena_path, &config.path);
+        let jar_path = std::fs::canonicalize(&configured_path)
+            .with_context(|| format!("cannot access referee JAR {}", configured_path.display()))?;
         let metadata = std::fs::metadata(&jar_path)
             .with_context(|| format!("cannot access referee JAR {}", jar_path.display()))?;
         if !metadata.is_file() {

--- a/src/referee_adapter.rs
+++ b/src/referee_adapter.rs
@@ -1,0 +1,455 @@
+use crate::config::{CodingameJarRefereeConfig, CommandRefereeConfig, RefereeConfig};
+use anyhow::{bail, Context};
+use serde::Deserialize;
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use tokio::process::Command;
+use tokio::time::timeout;
+
+pub const COMPATIBILITY_ARGUMENT: &str = "--cgarena-compat";
+pub const COMPATIBILITY_VERSION: &str = "cgarena-referee-v1";
+const COMPATIBILITY_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub enum RefereeAdapter<'a> {
+    CodingameJar(&'a CodingameJarRefereeConfig),
+    Command(&'a CommandRefereeConfig),
+}
+
+#[derive(Clone, Copy)]
+pub enum MatchResultSource {
+    CommandStdout,
+    CodingameReplay,
+}
+
+pub struct PreparedMatchCommand {
+    pub argv: Vec<String>,
+    pub result_source: MatchResultSource,
+}
+
+pub struct PreparedReplayCommand {
+    pub program: String,
+    pub args: Vec<String>,
+}
+
+impl<'a> From<&'a RefereeConfig> for RefereeAdapter<'a> {
+    fn from(config: &'a RefereeConfig) -> Self {
+        match config {
+            RefereeConfig::CodingameJar(config) => Self::CodingameJar(config),
+            RefereeConfig::Command(config) => Self::Command(config),
+        }
+    }
+}
+
+impl RefereeAdapter<'_> {
+    pub fn match_replay_required(&self) -> bool {
+        match self {
+            Self::CodingameJar(_) => true,
+            Self::Command(config) => config.play_match.contains("{REPLAY_PATH}"),
+        }
+    }
+
+    pub fn prepare_match_command(
+        &self,
+        seed: i64,
+        player_commands: &[String],
+        replay_path: Option<&Path>,
+    ) -> anyhow::Result<PreparedMatchCommand> {
+        match self {
+            Self::CodingameJar(config) => {
+                let replay_path =
+                    replay_path.context("codingame referee requires a replay path")?;
+                let mut argv = vec![
+                    config.java.as_deref().unwrap_or("java").to_string(),
+                    "--add-opens".to_string(),
+                    "java.base/java.lang=ALL-UNNAMED".to_string(),
+                    "-jar".to_string(),
+                    config.path.clone(),
+                ];
+                for (index, player_command) in player_commands.iter().enumerate() {
+                    argv.push(format!("-p{}", index + 1));
+                    argv.push(player_command.clone());
+                }
+                argv.extend([
+                    "-seed".to_string(),
+                    seed.to_string(),
+                    "-league".to_string(),
+                    config.league.unwrap_or(19).to_string(),
+                    "-l".to_string(),
+                    replay_path.to_string_lossy().to_string(),
+                ]);
+                Ok(PreparedMatchCommand {
+                    argv,
+                    result_source: MatchResultSource::CodingameReplay,
+                })
+            }
+            Self::Command(config) => {
+                let template = shell_words::split(&config.play_match)
+                    .context("invalid command referee play_match quoting")?;
+                let mut argv = Vec::new();
+                for part in template {
+                    match part.as_str() {
+                        "{SEED}" => argv.push(seed.to_string()),
+                        "{PLAYERS}" => argv.extend(player_commands.iter().cloned()),
+                        "{REPLAY_PATH}" => argv.push(
+                            replay_path
+                                .context("command referee requires a replay path")?
+                                .to_string_lossy()
+                                .to_string(),
+                        ),
+                        _ => {
+                            let player = part
+                                .strip_prefix("{P")
+                                .and_then(|value| value.strip_suffix('}'))
+                                .and_then(|value| value.parse::<usize>().ok());
+                            if let Some(player) = player {
+                                argv.push(
+                                    player_commands
+                                        .get(player.saturating_sub(1))
+                                        .with_context(|| {
+                                            format!("command referee references missing {part}")
+                                        })?
+                                        .clone(),
+                                );
+                            } else {
+                                argv.push(part);
+                            }
+                        }
+                    }
+                }
+                if argv.is_empty() {
+                    bail!("command referee play_match must not be blank");
+                }
+                Ok(PreparedMatchCommand {
+                    argv,
+                    result_source: MatchResultSource::CommandStdout,
+                })
+            }
+        }
+    }
+
+    pub fn prepare_replay_command(
+        &self,
+        artifact_path: &Path,
+        session_directory: &Path,
+        temporary_directory: &Path,
+        port: u16,
+        participant_count: u8,
+    ) -> anyhow::Result<PreparedReplayCommand> {
+        match self {
+            Self::CodingameJar(config) => Ok(PreparedReplayCommand {
+                program: config.java.as_deref().unwrap_or("java").to_string(),
+                args: vec![
+                    format!("-Djava.io.tmpdir={}", temporary_directory.display()),
+                    "--add-opens".to_string(),
+                    "java.base/java.lang=ALL-UNNAMED".to_string(),
+                    "-jar".to_string(),
+                    config.path.clone(),
+                    "-r".to_string(),
+                    artifact_path.to_string_lossy().to_string(),
+                    "-port".to_string(),
+                    port.to_string(),
+                ],
+            }),
+            Self::Command(config) => {
+                let mut parts = shell_words::split(&config.watch_replay)
+                    .context("invalid command referee watch_replay")?;
+                if parts.is_empty() {
+                    bail!("command referee watch_replay must not be blank");
+                }
+                let port = port.to_string();
+                let participant_count = participant_count.to_string();
+                let replacements = [
+                    ("{REPLAY_PATH}", artifact_path.to_str()),
+                    ("{REPLAY_DIR}", session_directory.to_str()),
+                    ("{PORT}", Some(port.as_str())),
+                    ("{PLAYER_COUNT}", Some(participant_count.as_str())),
+                ];
+                for (placeholder, value) in replacements {
+                    let value =
+                        value.with_context(|| format!("{placeholder} value is not valid UTF-8"))?;
+                    let part = parts
+                        .iter_mut()
+                        .find(|part| part.as_str() == placeholder)
+                        .with_context(|| {
+                            format!("command referee watch_replay must contain {placeholder}")
+                        })?;
+                    *part = value.to_string();
+                }
+                Ok(PreparedReplayCommand {
+                    program: parts.remove(0),
+                    args: parts,
+                })
+            }
+        }
+    }
+
+    pub async fn validate_startup(&self, arena_path: &Path) -> anyhow::Result<()> {
+        let Self::CodingameJar(config) = self else {
+            return Ok(());
+        };
+        let jar_path = resolve_path(arena_path, &config.path);
+        let metadata = std::fs::metadata(&jar_path)
+            .with_context(|| format!("cannot access referee JAR {}", jar_path.display()))?;
+        if !metadata.is_file() {
+            bail!("referee JAR is not a file: {}", jar_path.display());
+        }
+        std::fs::File::open(&jar_path)
+            .with_context(|| format!("referee JAR is not readable: {}", jar_path.display()))?;
+
+        let mut command = Command::new(config.java.as_deref().unwrap_or("java"));
+        command
+            .args(["--add-opens", "java.base/java.lang=ALL-UNNAMED", "-jar"])
+            .arg(&jar_path)
+            .arg(COMPATIBILITY_ARGUMENT)
+            .current_dir(arena_path)
+            .kill_on_drop(true);
+        let output = timeout(COMPATIBILITY_TIMEOUT, command.output())
+            .await
+            .with_context(|| {
+                format!(
+                    "timed out validating referee JAR compatibility: {}",
+                    jar_path.display()
+                )
+            })?
+            .with_context(|| format!("cannot execute referee JAR {}", jar_path.display()))?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if !output.status.success()
+            || !stdout
+                .lines()
+                .any(|line| line.trim() == COMPATIBILITY_VERSION)
+        {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let diagnostic = if stderr.trim().is_empty() {
+                stdout.trim()
+            } else {
+                stderr.trim()
+            };
+            bail!(
+                "unsupported referee JAR {} (expected {COMPATIBILITY_VERSION}, status {}): {}",
+                jar_path.display(),
+                output.status,
+                diagnostic
+            );
+        }
+        Ok(())
+    }
+}
+
+fn resolve_path(arena_path: &Path, configured_path: &str) -> PathBuf {
+    let path = Path::new(configured_path);
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        arena_path.join(path)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MatchCommandOutput {
+    #[serde(default)]
+    pub scores: Vec<i32>,
+    pub ranks: Vec<u8>,
+    pub errors: Vec<u8>,
+    #[serde(default)]
+    pub attributes: Vec<MatchCommandAttribute>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct MatchCommandAttribute {
+    pub name: String,
+    pub player: Option<usize>,
+    pub turn: Option<u16>,
+    pub value: String,
+}
+
+pub fn read_codingame_match_result(
+    path: &Path,
+    player_count: usize,
+) -> anyhow::Result<MatchCommandOutput> {
+    let replay: Value = serde_json::from_slice(&std::fs::read(path)?)
+        .context("codingame replay artifact must be valid JSON")?;
+    let score_map = replay
+        .get("scores")
+        .and_then(Value::as_object)
+        .context("codingame replay artifact has no scores object")?;
+    if score_map.len() != player_count {
+        bail!(
+            "codingame replay has {} scores for {player_count} bots",
+            score_map.len()
+        );
+    }
+    let scores = (0..player_count)
+        .map(|index| {
+            score_map
+                .get(&index.to_string())
+                .and_then(Value::as_i64)
+                .context("codingame replay score is not an integer")
+                .and_then(|score| {
+                    i32::try_from(score).context("codingame replay score is out of range")
+                })
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    let mut attributes = Vec::new();
+    if let Some(errors) = replay.get("errors").and_then(Value::as_object) {
+        for player in 0..player_count {
+            for line in errors
+                .get(&player.to_string())
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(Value::as_str)
+                .flat_map(str::lines)
+            {
+                if let Some(attribute) = parse_codingame_attribute(line, player) {
+                    attributes.push(attribute);
+                }
+            }
+        }
+    }
+    Ok(MatchCommandOutput {
+        ranks: scores
+            .iter()
+            .map(|score| scores.iter().filter(|other| score < *other).count() as u8)
+            .collect(),
+        errors: scores.iter().map(|score| u8::from(*score < 0)).collect(),
+        scores,
+        attributes,
+    })
+}
+
+pub fn validate_match_result(result: &MatchCommandOutput, bot_count: usize) -> anyhow::Result<()> {
+    if result.ranks.len() != bot_count || result.errors.len() != bot_count {
+        bail!("play match output must contain ranks and errors for {bot_count} bots");
+    }
+    if !result.scores.is_empty() && result.scores.len() != bot_count {
+        bail!(
+            "play match output has {} scores for {bot_count} bots",
+            result.scores.len()
+        );
+    }
+    if let Some(player) = result
+        .attributes
+        .iter()
+        .filter_map(|attribute| attribute.player)
+        .find(|player| *player >= bot_count)
+    {
+        bail!("play match output references missing player {player}");
+    }
+    Ok(())
+}
+
+fn parse_codingame_attribute(line: &str, player: usize) -> Option<MatchCommandAttribute> {
+    let line = line.trim();
+    let (owner, rest) = if let Some(rest) = strip_prefix_ignore_ascii_case(line, "[TDATA]") {
+        (None, rest)
+    } else if let Some(rest) = strip_prefix_ignore_ascii_case(line, "[PDATA]") {
+        (Some(player), rest)
+    } else {
+        return None;
+    };
+    let rest = rest.trim_start();
+    let (turn, rest) = if let Some(rest) = rest.strip_prefix('[') {
+        let (turn, rest) = rest.split_once(']')?;
+        (Some(turn.parse().ok()?), rest)
+    } else {
+        (None, rest)
+    };
+    let (name, value) = rest.trim().split_once('=')?;
+    let name = name.trim();
+    if name.is_empty()
+        || !name
+            .chars()
+            .all(|character| character.is_alphanumeric() || character == '_')
+    {
+        return None;
+    }
+    Some(MatchCommandAttribute {
+        name: name.to_string(),
+        player: owner,
+        turn,
+        value: value.trim().to_string(),
+    })
+}
+
+fn strip_prefix_ignore_ascii_case<'a>(value: &'a str, prefix: &str) -> Option<&'a str> {
+    value
+        .get(..prefix.len())
+        .filter(|candidate| candidate.eq_ignore_ascii_case(prefix))
+        .map(|_| &value[prefix.len()..])
+}
+
+pub async fn validate_codingame_replay(
+    artifact_path: &Path,
+    participant_count: u8,
+) -> anyhow::Result<()> {
+    let bytes = tokio::fs::read(artifact_path).await?;
+    let replay: Value = serde_json::from_slice(&bytes)?;
+    let agents = replay
+        .get("agents")
+        .and_then(Value::as_array)
+        .context("artifact has no agents array")?;
+    if agents.len() != usize::from(participant_count) {
+        bail!(
+            "artifact has {} participants, match has {participant_count}",
+            agents.len()
+        );
+    }
+    Ok(())
+}
+
+pub fn import_codingame_replay_bundle(source: &Path, destination: &Path) -> std::io::Result<()> {
+    copy_directory(source, destination)?;
+    normalize_replay_bundle(destination)
+}
+
+fn copy_directory(source: &Path, destination: &Path) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(source)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "renderer bundle contains a symbolic link",
+            ));
+        }
+        let target = destination.join(entry.file_name());
+        if file_type.is_dir() {
+            std::fs::create_dir_all(&target)?;
+            copy_directory(&entry.path(), &target)?;
+        } else if file_type.is_file() {
+            std::fs::copy(entry.path(), target)?;
+        }
+    }
+    Ok(())
+}
+
+fn normalize_replay_bundle(directory: &Path) -> std::io::Result<()> {
+    let assets = directory.join("assets");
+    if assets.is_dir() {
+        let nested = assets.join("assets");
+        std::fs::create_dir_all(&nested)?;
+        for entry in std::fs::read_dir(&assets)? {
+            let entry = entry?;
+            if entry
+                .path()
+                .extension()
+                .is_some_and(|extension| extension == "png")
+            {
+                std::fs::copy(entry.path(), nested.join(entry.file_name()))?;
+            }
+        }
+    }
+    let app = directory.join("app.js");
+    if app.is_file() {
+        let content = std::fs::read_to_string(&app)?
+            .replace("from '../config.js'", "from './config.js'")
+            .replace("from '../demo.js'", "from './demo.js'")
+            .replace(
+                "viewerUrl: '/core/Drawer.js'",
+                "viewerUrl: './core/Drawer.js'",
+            );
+        std::fs::write(app, content)?;
+    }
+    Ok(())
+}

--- a/src/replay_viewer.rs
+++ b/src/replay_viewer.rs
@@ -11,7 +11,7 @@ use tokio::{
     fs,
     io::{AsyncBufReadExt, AsyncReadExt, BufReader},
     net::TcpListener,
-    process::Command,
+    process::{Child, Command},
     sync::Mutex,
     time::{timeout, Instant},
 };
@@ -42,6 +42,7 @@ struct ReplayViewerInner {
     sessions: Mutex<HashMap<String, ReplaySession>>,
     startup_timeout: Duration,
     idle_lifetime: Duration,
+    cancellation_token: CancellationToken,
 }
 
 struct ReplaySession {
@@ -72,8 +73,8 @@ pub enum ReplayError {
     InvalidCommand(String),
     #[error("replay renderer failed to start: {0}")]
     StartupFailed(String),
-    #[error("replay renderer startup timed out")]
-    StartupTimeout,
+    #[error("replay renderer startup timed out: {0}")]
+    StartupTimeout(String),
     #[error("replay session not found")]
     SessionNotFound,
     #[error("replay asset not found")]
@@ -106,6 +107,7 @@ impl ReplayViewer {
             referee,
             STARTUP_TIMEOUT,
             SESSION_IDLE_LIFETIME,
+            cancellation_token.clone(),
         );
         viewer.spawn_cleanup_task(cancellation_token);
         viewer
@@ -117,6 +119,7 @@ impl ReplayViewer {
         referee: RefereeConfig,
         startup_timeout: Duration,
         idle_lifetime: Duration,
+        cancellation_token: CancellationToken,
     ) -> Self {
         let replay_artifacts = ReplayArtifacts::new(pool, arena_path.clone());
         Self {
@@ -127,6 +130,7 @@ impl ReplayViewer {
                 sessions: Mutex::new(HashMap::new()),
                 startup_timeout,
                 idle_lifetime,
+                cancellation_token,
             }),
         }
     }
@@ -243,7 +247,12 @@ impl ReplayViewer {
     ) -> Result<(), ReplayError> {
         if let RefereeConfig::CodingameJar(referee) = &self.inner.referee {
             return self
-                .generate_codingame_bundle(artifact_path, session_directory, referee)
+                .generate_codingame_bundle(
+                    artifact_path,
+                    session_directory,
+                    participant_count,
+                    referee,
+                )
                 .await;
         }
         let port = available_local_port().await?;
@@ -254,12 +263,16 @@ impl ReplayViewer {
             port,
             participant_count,
         )?;
-        let mut child = Command::new(&command_parts[0])
+        let mut command = Command::new(&command_parts[0]);
+        command
             .args(&command_parts[1..])
             .current_dir(&self.inner.arena_path)
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
-            .kill_on_drop(true)
+            .kill_on_drop(true);
+        #[cfg(unix)]
+        command.process_group(0);
+        let mut child = command
             .spawn()
             .map_err(|error| ReplayError::StartupFailed(error.to_string()))?;
         let stderr = child
@@ -267,14 +280,18 @@ impl ReplayViewer {
             .take()
             .ok_or_else(|| ReplayError::Internal("cannot capture renderer stderr".to_string()))?;
         let stderr_task = tokio::spawn(read_stderr(stderr));
-
         let status = match timeout(self.inner.startup_timeout, child.wait()).await {
             Ok(result) => result.map_err(|error| ReplayError::StartupFailed(error.to_string()))?,
             Err(_) => {
-                let _ = child.kill().await;
-                let _ = child.wait().await;
-                let _ = stderr_task.await;
-                return Err(ReplayError::StartupTimeout);
+                let _ = terminate_renderer(&mut child).await;
+                let stderr = stderr_task
+                    .await
+                    .ok()
+                    .and_then(Result::ok)
+                    .unwrap_or_default();
+                return Err(ReplayError::StartupTimeout(
+                    String::from_utf8_lossy(&stderr).trim().to_string(),
+                ));
             }
         };
         let stderr = stderr_task
@@ -289,9 +306,7 @@ impl ReplayViewer {
                 message
             }));
         }
-
-        let entrypoint = session_directory.join("test.html");
-        if !entrypoint.is_file() {
+        if !session_directory.join("test.html").is_file() {
             return Err(ReplayError::StartupFailed(
                 "renderer produced no test.html replay bundle".to_string(),
             ));
@@ -303,14 +318,39 @@ impl ReplayViewer {
         &self,
         artifact_path: &Path,
         session_directory: &Path,
+        participant_count: u8,
         referee: &crate::config::CodingameJarRefereeConfig,
     ) -> Result<(), ReplayError> {
+        validate_codingame_replay(artifact_path, participant_count).await?;
         let temporary_directory = session_directory.join(format!(".jvm-{}", Uuid::new_v4()));
         fs::create_dir_all(&temporary_directory)
             .await
             .map_err(|error| ReplayError::Internal(error.to_string()))?;
+        let temporary_directory = fs::canonicalize(&temporary_directory)
+            .await
+            .map_err(|error| ReplayError::Internal(error.to_string()))?;
+        let result = self
+            .run_codingame_renderer(
+                artifact_path,
+                session_directory,
+                &temporary_directory,
+                referee,
+            )
+            .await;
+        let _ = fs::remove_dir_all(&temporary_directory).await;
+        result
+    }
+
+    async fn run_codingame_renderer(
+        &self,
+        artifact_path: &Path,
+        session_directory: &Path,
+        temporary_directory: &Path,
+        referee: &crate::config::CodingameJarRefereeConfig,
+    ) -> Result<(), ReplayError> {
         let port = available_local_port().await?;
-        let mut child = Command::new(referee.java.as_deref().unwrap_or("java"))
+        let mut command = Command::new(referee.java.as_deref().unwrap_or("java"));
+        command
             .args([
                 format!("-Djava.io.tmpdir={}", temporary_directory.display()),
                 "--add-opens".to_string(),
@@ -325,46 +365,57 @@ impl ReplayViewer {
             .current_dir(&self.inner.arena_path)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .kill_on_drop(true)
+            .kill_on_drop(true);
+        #[cfg(unix)]
+        command.process_group(0);
+        let mut child = command
             .spawn()
             .map_err(|error| ReplayError::StartupFailed(error.to_string()))?;
         let stdout = child
             .stdout
             .take()
-            .ok_or_else(|| ReplayError::Internal("cannot capture renderer stdout".to_string()))?;
+            .expect("renderer stdout is configured as piped");
+        let stderr = child
+            .stderr
+            .take()
+            .expect("renderer stderr is configured as piped");
+        let stderr_task = tokio::spawn(read_stderr(stderr));
         let mut lines = BufReader::new(stdout).lines();
-        let exposed = timeout(self.inner.startup_timeout, async {
-            loop {
-                let line = lines
-                    .next_line()
-                    .await
-                    .map_err(|error| ReplayError::StartupFailed(error.to_string()))?
-                    .ok_or_else(|| {
-                        ReplayError::StartupFailed(
-                            "renderer exited without producing a replay bundle".to_string(),
-                        )
-                    })?;
-                if let Some(path) = line.strip_prefix("Exposed web server dir: ") {
-                    return Ok::<PathBuf, ReplayError>(PathBuf::from(path.trim()));
-                }
+        let exposed_result = tokio::select! {
+            _ = self.inner.cancellation_token.cancelled() => {
+                Err(ReplayError::StartupFailed("renderer canceled during arena shutdown".to_string()))
             }
-        })
-        .await
-        .map_err(|_| ReplayError::StartupTimeout)??;
-        if !exposed.starts_with(&temporary_directory) || !exposed.is_dir() {
-            let _ = child.kill().await;
-            let _ = child.wait().await;
+            result = timeout(self.inner.startup_timeout, read_exposed_directory(&mut lines)) => {
+                result.unwrap_or_else(|_| Err(ReplayError::StartupTimeout(String::new())))
+            }
+        };
+        let termination_result = terminate_renderer(&mut child).await;
+        let stderr = stderr_task
+            .await
+            .map_err(|error| ReplayError::Internal(error.to_string()))?
+            .map_err(|error| ReplayError::Internal(error.to_string()))?;
+        let exposed = exposed_result.map_err(|error| with_renderer_stderr(error, &stderr))?;
+        termination_result.map_err(|error| {
+            ReplayError::StartupFailed(format!("cannot reap renderer: {error}"))
+        })?;
+
+        let exposed = if exposed.is_absolute() {
+            exposed
+        } else {
+            self.inner.arena_path.join(exposed)
+        };
+        let exposed = fs::canonicalize(&exposed)
+            .await
+            .map_err(|error| ReplayError::StartupFailed(error.to_string()))?;
+        if exposed == temporary_directory || !exposed.starts_with(temporary_directory) {
             return Err(ReplayError::StartupFailed(
-                "renderer exposed an invalid replay directory".to_string(),
+                "renderer exposed a directory outside its temporary directory".to_string(),
             ));
         }
         copy_directory(&exposed, session_directory)
             .map_err(|error| ReplayError::StartupFailed(error.to_string()))?;
         normalize_replay_bundle(session_directory)
             .map_err(|error| ReplayError::StartupFailed(error.to_string()))?;
-        let _ = child.kill().await;
-        let _ = child.wait().await;
-        let _ = fs::remove_dir_all(&temporary_directory).await;
         if !session_directory.join("test.html").is_file() {
             return Err(ReplayError::StartupFailed(
                 "renderer produced no test.html replay bundle".to_string(),
@@ -411,14 +462,100 @@ impl ReplayViewer {
     }
 }
 
+async fn validate_codingame_replay(
+    artifact_path: &Path,
+    participant_count: u8,
+) -> Result<(), ReplayError> {
+    let bytes = fs::read(artifact_path)
+        .await
+        .map_err(|error| ReplayError::InvalidArtifact(error.to_string()))?;
+    let replay: serde_json::Value = serde_json::from_slice(&bytes)
+        .map_err(|error| ReplayError::InvalidArtifact(error.to_string()))?;
+    let agents = replay
+        .get("agents")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| ReplayError::InvalidArtifact("artifact has no agents array".to_string()))?;
+    if agents.len() != usize::from(participant_count) {
+        return Err(ReplayError::InvalidArtifact(format!(
+            "artifact has {} participants, match has {participant_count}",
+            agents.len()
+        )));
+    }
+    Ok(())
+}
+
+async fn read_exposed_directory<R>(lines: &mut tokio::io::Lines<R>) -> Result<PathBuf, ReplayError>
+where
+    R: tokio::io::AsyncBufRead + Unpin,
+{
+    loop {
+        let line = lines
+            .next_line()
+            .await
+            .map_err(|error| ReplayError::StartupFailed(error.to_string()))?
+            .ok_or_else(|| {
+                ReplayError::StartupFailed(
+                    "renderer exited without producing a replay bundle".to_string(),
+                )
+            })?;
+        if let Some(path) = line.strip_prefix("Exposed web server dir: ") {
+            return Ok(PathBuf::from(path.trim()));
+        }
+    }
+}
+
+fn with_renderer_stderr(error: ReplayError, stderr: &[u8]) -> ReplayError {
+    let stderr = String::from_utf8_lossy(stderr).trim().to_string();
+    match (error, stderr.is_empty()) {
+        (ReplayError::StartupFailed(message), false) => {
+            ReplayError::StartupFailed(format!("{message}: {stderr}"))
+        }
+        (ReplayError::StartupTimeout(_), false) => ReplayError::StartupTimeout(stderr),
+        (error, _) => error,
+    }
+}
+
+async fn terminate_renderer(child: &mut Child) -> std::io::Result<()> {
+    #[cfg(unix)]
+    if let Some(pid) = child.id() {
+        // The renderer is launched in its own process group; a negative PID addresses the group.
+        let result = unsafe { libc::kill(-(pid as i32), libc::SIGKILL) };
+        if result == -1 {
+            let error = std::io::Error::last_os_error();
+            if error.raw_os_error() != Some(libc::ESRCH) {
+                return Err(error);
+            }
+        }
+    }
+    #[cfg(windows)]
+    if let Some(pid) = child.id() {
+        let _ = Command::new("taskkill")
+            .args(["/PID", &pid.to_string(), "/T", "/F"])
+            .status()
+            .await;
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = child.start_kill();
+    }
+    child.wait().await.map(|_| ())
+}
+
 fn copy_directory(source: &Path, destination: &Path) -> std::io::Result<()> {
     for entry in std::fs::read_dir(source)? {
         let entry = entry?;
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "renderer bundle contains a symbolic link",
+            ));
+        }
         let target = destination.join(entry.file_name());
-        if entry.file_type()?.is_dir() {
+        if file_type.is_dir() {
             std::fs::create_dir_all(&target)?;
             copy_directory(&entry.path(), &target)?;
-        } else {
+        } else if file_type.is_file() {
             std::fs::copy(entry.path(), target)?;
         }
     }
@@ -592,8 +729,71 @@ mod tests {
             }),
             startup_timeout,
             Duration::from_secs(60),
+            CancellationToken::new(),
         );
         (temporary_directory, viewer, replay_match.id, artifact_path)
+    }
+    async fn assert_process_gone(pid_path: &Path) {
+        let pid: i32 = std::fs::read_to_string(pid_path)
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap();
+        for _ in 0..100 {
+            if unsafe { libc::kill(pid, 0) } == -1
+                && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
+            {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("process {pid} was not reaped");
+    }
+
+    async fn codingame_fixture(
+        script_body: &str,
+        replay: &str,
+        startup_timeout: Duration,
+    ) -> (TempDir, ReplayViewer, PathBuf, PathBuf, CancellationToken) {
+        let temporary_directory = tempfile::tempdir().unwrap();
+        let arena_path = temporary_directory.path().join("codingame arena");
+        fs::create_dir_all(&arena_path).await.unwrap();
+        let artifact_path = arena_path.join("replay.json");
+        fs::write(&artifact_path, replay).await.unwrap();
+        let session_directory = arena_path.join("session");
+        fs::create_dir_all(&session_directory).await.unwrap();
+        let launcher_path = arena_path.join("fake java.sh");
+        fs::write(
+            &launcher_path,
+            format!(
+                "#!/bin/sh\nset -eu\ntmp=''\nfor argument in \"$@\"; do\n  case \"$argument\" in\n    -Djava.io.tmpdir=*) tmp=\"${{argument#*=}}\" ;;\n  esac\ndone\n{script_body}\n"
+            ),
+        )
+        .await
+        .unwrap();
+        let mut permissions = std::fs::metadata(&launcher_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&launcher_path, permissions).unwrap();
+        let cancellation_token = CancellationToken::new();
+        let viewer = ReplayViewer::new_with_timeouts(
+            db::in_memory().await.unwrap(),
+            arena_path,
+            RefereeConfig::CodingameJar(crate::config::CodingameJarRefereeConfig {
+                path: "fixture.jar".to_string(),
+                java: Some(launcher_path.to_string_lossy().to_string()),
+                league: None,
+            }),
+            startup_timeout,
+            Duration::from_secs(60),
+            cancellation_token.clone(),
+        );
+        (
+            temporary_directory,
+            viewer,
+            artifact_path,
+            session_directory,
+            cancellation_token,
+        )
     }
 
     #[tokio::test]
@@ -633,7 +833,7 @@ mod tests {
         let started = Instant::now();
         assert!(matches!(
             viewer.watch(match_id).await,
-            Err(ReplayError::StartupTimeout)
+            Err(ReplayError::StartupTimeout(_))
         ));
         assert!(started.elapsed() < Duration::from_secs(1));
     }
@@ -669,6 +869,196 @@ mod tests {
         assert!(matches!(
             viewer.watch(match_id).await,
             Err(ReplayError::InvalidArtifact(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn codingame_renderer_normalizes_bundle_and_reaps_process() {
+        let (temporary_directory, viewer, artifact, session, _cancellation_token) =
+            codingame_fixture(
+            r#"mkdir -p "$tmp/codingame/assets"
+printf '<html>native replay</html>' > "$tmp/codingame/test.html"
+printf png > "$tmp/codingame/assets/image.png"
+printf "from '../config.js'; from '../demo.js'; viewerUrl: '/core/Drawer.js'" > "$tmp/codingame/app.js"
+echo $$ > renderer.pid
+echo "Exposed web server dir: $tmp/codingame"
+exec sleep 30"#,
+            r#"{"agents":[{},{}]}"#,
+            Duration::from_secs(2),
+        )
+        .await;
+
+        viewer
+            .generate_bundle(&artifact, &session, 2)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            fs::read(session.join("test.html")).await.unwrap(),
+            b"<html>native replay</html>"
+        );
+        assert!(session.join("assets/assets/image.png").is_file());
+        let app = fs::read_to_string(session.join("app.js")).await.unwrap();
+        assert!(app.contains("from './config.js'"));
+        assert!(app.contains("from './demo.js'"));
+        assert!(app.contains("viewerUrl: './core/Drawer.js'"));
+        assert!(!std::fs::read_dir(&session).unwrap().any(|entry| {
+            entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".jvm-")
+        }));
+        let pid: i32 = std::fs::read_to_string(
+            temporary_directory
+                .path()
+                .join("codingame arena/renderer.pid"),
+        )
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+        assert_eq!(unsafe { libc::kill(pid, 0) }, -1);
+        assert_eq!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(libc::ESRCH)
+        );
+    }
+
+    #[tokio::test]
+    async fn codingame_replay_rejects_participant_mismatch_before_launch() {
+        let (temporary_directory, viewer, artifact, session, _cancellation_token) =
+            codingame_fixture(
+                "touch renderer-started",
+                r#"{"agents":[{}]}"#,
+                Duration::from_secs(2),
+            )
+            .await;
+
+        assert!(matches!(
+            viewer.generate_bundle(&artifact, &session, 2).await,
+            Err(ReplayError::InvalidArtifact(message)) if message.contains("1 participants")
+        ));
+        assert!(!temporary_directory
+            .path()
+            .join("codingame arena/renderer-started")
+            .exists());
+    }
+
+    #[tokio::test]
+    async fn codingame_renderer_reports_stderr_on_timeout_and_is_reaped() {
+        let (temporary_directory, viewer, artifact, session, _cancellation_token) =
+            codingame_fixture(
+            "echo $$ > renderer.pid\nsleep 30 &\necho $! > renderer-child.pid\necho actionable-timeout >&2\nwait",
+            r#"{"agents":[{},{}]}"#,
+            Duration::from_secs(1),
+        )
+        .await;
+
+        let result = viewer.generate_bundle(&artifact, &session, 2).await;
+        assert!(
+            matches!(
+                &result,
+                Err(ReplayError::StartupTimeout(message))
+                    if message.contains("actionable-timeout")
+            ),
+            "unexpected result: {result:?}"
+        );
+        assert_process_gone(
+            &temporary_directory
+                .path()
+                .join("codingame arena/renderer.pid"),
+        )
+        .await;
+        assert_process_gone(
+            &temporary_directory
+                .path()
+                .join("codingame arena/renderer-child.pid"),
+        )
+        .await;
+        assert!(!std::fs::read_dir(&session).unwrap().any(|entry| {
+            entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".jvm-")
+        }));
+    }
+
+    #[tokio::test]
+    async fn codingame_renderer_is_reaped_on_cancellation() {
+        let (temporary_directory, viewer, artifact, session, cancellation_token) =
+            codingame_fixture(
+                "echo $$ > renderer.pid\nsleep 30 &\necho $! > renderer-child.pid\nwait",
+                r#"{"agents":[{},{}]}"#,
+                Duration::from_secs(30),
+            )
+            .await;
+        let renderer_pid = temporary_directory
+            .path()
+            .join("codingame arena/renderer.pid");
+        let renderer_child_pid = temporary_directory
+            .path()
+            .join("codingame arena/renderer-child.pid");
+        let start_marker = renderer_child_pid.clone();
+        let cancellation = tokio::spawn(async move {
+            for _ in 0..200 {
+                if start_marker.exists() {
+                    cancellation_token.cancel();
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            panic!("renderer did not start");
+        });
+
+        let result = viewer.generate_bundle(&artifact, &session, 2).await;
+        cancellation.await.unwrap();
+
+        assert!(matches!(
+            result,
+            Err(ReplayError::StartupFailed(message))
+                if message.contains("canceled during arena shutdown")
+        ));
+        assert_process_gone(&renderer_pid).await;
+        assert_process_gone(&renderer_child_pid).await;
+        assert!(!std::fs::read_dir(&session).unwrap().any(|entry| {
+            entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".jvm-")
+        }));
+    }
+    #[tokio::test]
+    async fn codingame_renderer_returns_early_stderr() {
+        let (_temporary_directory, viewer, artifact, session, _cancellation_token) =
+            codingame_fixture(
+                "echo actionable-failure >&2\nexit 7",
+                r#"{"agents":[{},{}]}"#,
+                Duration::from_secs(2),
+            )
+            .await;
+
+        assert!(matches!(
+            viewer.generate_bundle(&artifact, &session, 2).await,
+            Err(ReplayError::StartupFailed(message)) if message.contains("actionable-failure")
+        ));
+    }
+
+    #[tokio::test]
+    async fn codingame_renderer_rejects_exposed_directory_escape() {
+        let (_temporary_directory, viewer, artifact, session, _cancellation_token) =
+            codingame_fixture(
+                "mkdir -p outside\necho \"Exposed web server dir: $(pwd)/outside\"\nexec sleep 30",
+                r#"{"agents":[{},{}]}"#,
+                Duration::from_secs(2),
+            )
+            .await;
+
+        assert!(matches!(
+            viewer.generate_bundle(&artifact, &session, 2).await,
+            Err(ReplayError::StartupFailed(message)) if message.contains("outside")
         ));
     }
 

--- a/src/replay_viewer.rs
+++ b/src/replay_viewer.rs
@@ -1,3 +1,4 @@
+use crate::config::RefereeConfig;
 use std::{
     collections::HashMap,
     path::{Component, Path, PathBuf},
@@ -8,7 +9,7 @@ use std::{
 
 use tokio::{
     fs,
-    io::AsyncReadExt,
+    io::{AsyncBufReadExt, AsyncReadExt, BufReader},
     net::TcpListener,
     process::Command,
     sync::Mutex,
@@ -37,7 +38,7 @@ pub struct ReplayViewer {
 struct ReplayViewerInner {
     replay_artifacts: ReplayArtifacts,
     arena_path: PathBuf,
-    command: String,
+    referee: RefereeConfig,
     sessions: Mutex<HashMap<String, ReplaySession>>,
     startup_timeout: Duration,
     idle_lifetime: Duration,
@@ -96,13 +97,13 @@ impl ReplayViewer {
     pub fn new(
         pool: sqlx::SqlitePool,
         arena_path: PathBuf,
-        command: String,
+        referee: RefereeConfig,
         cancellation_token: CancellationToken,
     ) -> Self {
         let viewer = Self::new_with_timeouts(
             pool,
             arena_path,
-            command,
+            referee,
             STARTUP_TIMEOUT,
             SESSION_IDLE_LIFETIME,
         );
@@ -113,7 +114,7 @@ impl ReplayViewer {
     fn new_with_timeouts(
         pool: sqlx::SqlitePool,
         arena_path: PathBuf,
-        command: String,
+        referee: RefereeConfig,
         startup_timeout: Duration,
         idle_lifetime: Duration,
     ) -> Self {
@@ -122,7 +123,7 @@ impl ReplayViewer {
             inner: Arc::new(ReplayViewerInner {
                 replay_artifacts,
                 arena_path,
-                command,
+                referee,
                 sessions: Mutex::new(HashMap::new()),
                 startup_timeout,
                 idle_lifetime,
@@ -240,9 +241,14 @@ impl ReplayViewer {
         session_directory: &Path,
         participant_count: u8,
     ) -> Result<(), ReplayError> {
+        if let RefereeConfig::CodingameJar(referee) = &self.inner.referee {
+            return self
+                .generate_codingame_bundle(artifact_path, session_directory, referee)
+                .await;
+        }
         let port = available_local_port().await?;
         let command_parts = replay_command(
-            &self.inner.command,
+            &self.inner.referee,
             artifact_path,
             session_directory,
             port,
@@ -293,6 +299,80 @@ impl ReplayViewer {
         Ok(())
     }
 
+    async fn generate_codingame_bundle(
+        &self,
+        artifact_path: &Path,
+        session_directory: &Path,
+        referee: &crate::config::CodingameJarRefereeConfig,
+    ) -> Result<(), ReplayError> {
+        let temporary_directory = session_directory.join(format!(".jvm-{}", Uuid::new_v4()));
+        fs::create_dir_all(&temporary_directory)
+            .await
+            .map_err(|error| ReplayError::Internal(error.to_string()))?;
+        let port = available_local_port().await?;
+        let mut child = Command::new(referee.java.as_deref().unwrap_or("java"))
+            .args([
+                format!("-Djava.io.tmpdir={}", temporary_directory.display()),
+                "--add-opens".to_string(),
+                "java.base/java.lang=ALL-UNNAMED".to_string(),
+                "-jar".to_string(),
+                referee.path.clone(),
+                "-r".to_string(),
+                artifact_path.to_string_lossy().to_string(),
+                "-port".to_string(),
+                port.to_string(),
+            ])
+            .current_dir(&self.inner.arena_path)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|error| ReplayError::StartupFailed(error.to_string()))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| ReplayError::Internal("cannot capture renderer stdout".to_string()))?;
+        let mut lines = BufReader::new(stdout).lines();
+        let exposed = timeout(self.inner.startup_timeout, async {
+            loop {
+                let line = lines
+                    .next_line()
+                    .await
+                    .map_err(|error| ReplayError::StartupFailed(error.to_string()))?
+                    .ok_or_else(|| {
+                        ReplayError::StartupFailed(
+                            "renderer exited without producing a replay bundle".to_string(),
+                        )
+                    })?;
+                if let Some(path) = line.strip_prefix("Exposed web server dir: ") {
+                    return Ok::<PathBuf, ReplayError>(PathBuf::from(path.trim()));
+                }
+            }
+        })
+        .await
+        .map_err(|_| ReplayError::StartupTimeout)??;
+        if !exposed.starts_with(&temporary_directory) || !exposed.is_dir() {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            return Err(ReplayError::StartupFailed(
+                "renderer exposed an invalid replay directory".to_string(),
+            ));
+        }
+        copy_directory(&exposed, session_directory)
+            .map_err(|error| ReplayError::StartupFailed(error.to_string()))?;
+        normalize_replay_bundle(session_directory)
+            .map_err(|error| ReplayError::StartupFailed(error.to_string()))?;
+        let _ = child.kill().await;
+        let _ = child.wait().await;
+        let _ = fs::remove_dir_all(&temporary_directory).await;
+        if !session_directory.join("test.html").is_file() {
+            return Err(ReplayError::StartupFailed(
+                "renderer produced no test.html replay bundle".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
     fn spawn_cleanup_task(&self, cancellation_token: CancellationToken) {
         let viewer = self.clone();
         tokio::spawn(async move {
@@ -331,14 +411,62 @@ impl ReplayViewer {
     }
 }
 
+fn copy_directory(source: &Path, destination: &Path) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(source)? {
+        let entry = entry?;
+        let target = destination.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            std::fs::create_dir_all(&target)?;
+            copy_directory(&entry.path(), &target)?;
+        } else {
+            std::fs::copy(entry.path(), target)?;
+        }
+    }
+    Ok(())
+}
+fn normalize_replay_bundle(directory: &Path) -> std::io::Result<()> {
+    let assets = directory.join("assets");
+    if assets.is_dir() {
+        let nested = assets.join("assets");
+        std::fs::create_dir_all(&nested)?;
+        for entry in std::fs::read_dir(&assets)? {
+            let entry = entry?;
+            if entry
+                .path()
+                .extension()
+                .is_some_and(|extension| extension == "png")
+            {
+                std::fs::copy(entry.path(), nested.join(entry.file_name()))?;
+            }
+        }
+    }
+    let app = directory.join("app.js");
+    if app.is_file() {
+        let content = std::fs::read_to_string(&app)?
+            .replace("from '../config.js'", "from './config.js'")
+            .replace("from '../demo.js'", "from './demo.js'")
+            .replace(
+                "viewerUrl: '/core/Drawer.js'",
+                "viewerUrl: './core/Drawer.js'",
+            );
+        std::fs::write(app, content)?;
+    }
+    Ok(())
+}
+
 fn replay_command(
-    template: &str,
+    referee: &RefereeConfig,
     artifact_path: &Path,
     session_directory: &Path,
     port: u16,
     participant_count: u8,
 ) -> Result<Vec<String>, ReplayError> {
-    let mut parts = shell_words::split(template)
+    let RefereeConfig::Command(referee) = referee else {
+        return Err(ReplayError::InvalidCommand(
+            "codingame_jar replay rendering is not implemented".to_string(),
+        ));
+    };
+    let mut parts = shell_words::split(&referee.watch_replay)
         .map_err(|error| ReplayError::InvalidCommand(error.to_string()))?;
     if parts.is_empty() {
         return Err(ReplayError::InvalidCommand(
@@ -458,7 +586,10 @@ mod tests {
         let viewer = ReplayViewer::new_with_timeouts(
             pool,
             arena_path,
-            command,
+            RefereeConfig::Command(crate::config::CommandRefereeConfig {
+                play_match: "true".to_string(),
+                watch_replay: command,
+            }),
             startup_timeout,
             Duration::from_secs(60),
         );
@@ -544,7 +675,11 @@ mod tests {
     #[test]
     fn replay_command_preserves_quoted_paths_and_requires_contract() {
         let command = replay_command(
-            "\"renderer path\" {REPLAY_PATH} {REPLAY_DIR} {PORT} {PLAYER_COUNT}",
+            &RefereeConfig::Command(crate::config::CommandRefereeConfig {
+                play_match: "true".to_string(),
+                watch_replay: "\"renderer path\" {REPLAY_PATH} {REPLAY_DIR} {PORT} {PLAYER_COUNT}"
+                    .to_string(),
+            }),
             Path::new("/artifact path/replay.json"),
             Path::new("/session path"),
             12345,
@@ -564,7 +699,10 @@ mod tests {
 
         assert!(matches!(
             replay_command(
-                "renderer {REPLAY_PATH}",
+                &RefereeConfig::Command(crate::config::CommandRefereeConfig {
+                    play_match: "true".to_string(),
+                    watch_replay: "renderer {REPLAY_PATH}".to_string(),
+                }),
                 Path::new("replay.json"),
                 Path::new("session"),
                 1,

--- a/src/replay_viewer.rs
+++ b/src/replay_viewer.rs
@@ -1,4 +1,7 @@
 use crate::config::RefereeConfig;
+use crate::referee_adapter::{
+    import_codingame_replay_bundle, validate_codingame_replay, RefereeAdapter,
+};
 use std::{
     collections::HashMap,
     path::{Component, Path, PathBuf},
@@ -245,45 +248,41 @@ impl ReplayViewer {
         session_directory: &Path,
         participant_count: u8,
     ) -> Result<(), ReplayError> {
-        if let RefereeConfig::CodingameJar(referee) = &self.inner.referee {
+        if matches!(self.inner.referee, RefereeConfig::CodingameJar(_)) {
             return self
-                .generate_codingame_bundle(
-                    artifact_path,
-                    session_directory,
-                    participant_count,
-                    referee,
-                )
+                .generate_codingame_bundle(artifact_path, session_directory, participant_count)
                 .await;
         }
         let port = available_local_port().await?;
-        let command_parts = replay_command(
-            &self.inner.referee,
-            artifact_path,
-            session_directory,
-            port,
-            participant_count,
-        )?;
-        let mut command = Command::new(&command_parts[0]);
+        let prepared = RefereeAdapter::from(&self.inner.referee)
+            .prepare_replay_command(
+                artifact_path,
+                session_directory,
+                session_directory,
+                port,
+                participant_count,
+            )
+            .map_err(|error| ReplayError::InvalidCommand(error.to_string()))?;
+        let mut command = Command::new(prepared.program);
         command
-            .args(&command_parts[1..])
+            .args(prepared.args)
             .current_dir(&self.inner.arena_path)
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
         #[cfg(unix)]
         command.process_group(0);
-        let mut child = command
-            .spawn()
+        let mut renderer = ManagedRenderer::spawn(command)
             .map_err(|error| ReplayError::StartupFailed(error.to_string()))?;
-        let stderr = child
-            .stderr
-            .take()
-            .ok_or_else(|| ReplayError::Internal("cannot capture renderer stderr".to_string()))?;
+        let stderr =
+            renderer.child_mut().stderr.take().ok_or_else(|| {
+                ReplayError::Internal("cannot capture renderer stderr".to_string())
+            })?;
         let stderr_task = tokio::spawn(read_stderr(stderr));
-        let status = match timeout(self.inner.startup_timeout, child.wait()).await {
+        let status = match timeout(self.inner.startup_timeout, renderer.wait()).await {
             Ok(result) => result.map_err(|error| ReplayError::StartupFailed(error.to_string()))?,
             Err(_) => {
-                let _ = terminate_renderer(&mut child).await;
+                let _ = renderer.terminate().await;
                 let stderr = stderr_task
                     .await
                     .ok()
@@ -319,25 +318,23 @@ impl ReplayViewer {
         artifact_path: &Path,
         session_directory: &Path,
         participant_count: u8,
-        referee: &crate::config::CodingameJarRefereeConfig,
     ) -> Result<(), ReplayError> {
-        validate_codingame_replay(artifact_path, participant_count).await?;
+        validate_codingame_replay(artifact_path, participant_count)
+            .await
+            .map_err(|error| ReplayError::InvalidArtifact(error.to_string()))?;
         let temporary_directory = session_directory.join(format!(".jvm-{}", Uuid::new_v4()));
         fs::create_dir_all(&temporary_directory)
             .await
             .map_err(|error| ReplayError::Internal(error.to_string()))?;
-        let temporary_directory = fs::canonicalize(&temporary_directory)
-            .await
-            .map_err(|error| ReplayError::Internal(error.to_string()))?;
+        let temporary_directory = RendererTemporaryDirectory::new(
+            fs::canonicalize(&temporary_directory)
+                .await
+                .map_err(|error| ReplayError::Internal(error.to_string()))?,
+        );
         let result = self
-            .run_codingame_renderer(
-                artifact_path,
-                session_directory,
-                &temporary_directory,
-                referee,
-            )
+            .run_codingame_renderer(artifact_path, session_directory, temporary_directory.path())
             .await;
-        let _ = fs::remove_dir_all(&temporary_directory).await;
+        let _ = fs::remove_dir_all(temporary_directory.path()).await;
         result
     }
 
@@ -346,36 +343,35 @@ impl ReplayViewer {
         artifact_path: &Path,
         session_directory: &Path,
         temporary_directory: &Path,
-        referee: &crate::config::CodingameJarRefereeConfig,
     ) -> Result<(), ReplayError> {
         let port = available_local_port().await?;
-        let mut command = Command::new(referee.java.as_deref().unwrap_or("java"));
+        let prepared = RefereeAdapter::from(&self.inner.referee)
+            .prepare_replay_command(
+                artifact_path,
+                session_directory,
+                temporary_directory,
+                port,
+                0,
+            )
+            .map_err(|error| ReplayError::InvalidCommand(error.to_string()))?;
+        let mut command = Command::new(prepared.program);
         command
-            .args([
-                format!("-Djava.io.tmpdir={}", temporary_directory.display()),
-                "--add-opens".to_string(),
-                "java.base/java.lang=ALL-UNNAMED".to_string(),
-                "-jar".to_string(),
-                referee.path.clone(),
-                "-r".to_string(),
-                artifact_path.to_string_lossy().to_string(),
-                "-port".to_string(),
-                port.to_string(),
-            ])
+            .args(prepared.args)
             .current_dir(&self.inner.arena_path)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
         #[cfg(unix)]
         command.process_group(0);
-        let mut child = command
-            .spawn()
+        let mut renderer = ManagedRenderer::spawn(command)
             .map_err(|error| ReplayError::StartupFailed(error.to_string()))?;
-        let stdout = child
+        let stdout = renderer
+            .child_mut()
             .stdout
             .take()
             .expect("renderer stdout is configured as piped");
-        let stderr = child
+        let stderr = renderer
+            .child_mut()
             .stderr
             .take()
             .expect("renderer stderr is configured as piped");
@@ -389,7 +385,7 @@ impl ReplayViewer {
                 result.unwrap_or_else(|_| Err(ReplayError::StartupTimeout(String::new())))
             }
         };
-        let termination_result = terminate_renderer(&mut child).await;
+        let termination_result = renderer.terminate().await;
         let stderr = stderr_task
             .await
             .map_err(|error| ReplayError::Internal(error.to_string()))?
@@ -412,9 +408,7 @@ impl ReplayViewer {
                 "renderer exposed a directory outside its temporary directory".to_string(),
             ));
         }
-        copy_directory(&exposed, session_directory)
-            .map_err(|error| ReplayError::StartupFailed(error.to_string()))?;
-        normalize_replay_bundle(session_directory)
+        import_codingame_replay_bundle(&exposed, session_directory)
             .map_err(|error| ReplayError::StartupFailed(error.to_string()))?;
         if !session_directory.join("test.html").is_file() {
             return Err(ReplayError::StartupFailed(
@@ -462,28 +456,6 @@ impl ReplayViewer {
     }
 }
 
-async fn validate_codingame_replay(
-    artifact_path: &Path,
-    participant_count: u8,
-) -> Result<(), ReplayError> {
-    let bytes = fs::read(artifact_path)
-        .await
-        .map_err(|error| ReplayError::InvalidArtifact(error.to_string()))?;
-    let replay: serde_json::Value = serde_json::from_slice(&bytes)
-        .map_err(|error| ReplayError::InvalidArtifact(error.to_string()))?;
-    let agents = replay
-        .get("agents")
-        .and_then(serde_json::Value::as_array)
-        .ok_or_else(|| ReplayError::InvalidArtifact("artifact has no agents array".to_string()))?;
-    if agents.len() != usize::from(participant_count) {
-        return Err(ReplayError::InvalidArtifact(format!(
-            "artifact has {} participants, match has {participant_count}",
-            agents.len()
-        )));
-    }
-    Ok(())
-}
-
 async fn read_exposed_directory<R>(lines: &mut tokio::io::Lines<R>) -> Result<PathBuf, ReplayError>
 where
     R: tokio::io::AsyncBufRead + Unpin,
@@ -515,18 +487,93 @@ fn with_renderer_stderr(error: ReplayError, stderr: &[u8]) -> ReplayError {
     }
 }
 
-async fn terminate_renderer(child: &mut Child) -> std::io::Result<()> {
-    #[cfg(unix)]
-    if let Some(pid) = child.id() {
-        // The renderer is launched in its own process group; a negative PID addresses the group.
-        let result = unsafe { libc::kill(-(pid as i32), libc::SIGKILL) };
-        if result == -1 {
-            let error = std::io::Error::last_os_error();
-            if error.raw_os_error() != Some(libc::ESRCH) {
-                return Err(error);
-            }
+struct RendererTemporaryDirectory {
+    path: PathBuf,
+}
+
+impl RendererTemporaryDirectory {
+    fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for RendererTemporaryDirectory {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+struct ManagedRenderer {
+    child: Option<Child>,
+}
+
+impl ManagedRenderer {
+    fn spawn(mut command: Command) -> std::io::Result<Self> {
+        Ok(Self {
+            child: Some(command.spawn()?),
+        })
+    }
+
+    fn child_mut(&mut self) -> &mut Child {
+        self.child
+            .as_mut()
+            .expect("managed renderer child is present")
+    }
+
+    async fn wait(&mut self) -> std::io::Result<std::process::ExitStatus> {
+        let status = self.child_mut().wait().await?;
+        self.child.take();
+        Ok(status)
+    }
+
+    async fn terminate(&mut self) -> std::io::Result<()> {
+        let Some(mut child) = self.child.take() else {
+            return Ok(());
+        };
+        terminate_renderer(&mut child).await
+    }
+}
+
+impl Drop for ManagedRenderer {
+    fn drop(&mut self) {
+        let Some(mut child) = self.child.take() else {
+            return;
+        };
+        #[cfg(unix)]
+        let _ = kill_renderer_process_group(&child);
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                let _ = terminate_renderer(&mut child).await;
+            });
+        } else {
+            let _ = child.start_kill();
         }
     }
+}
+
+#[cfg(unix)]
+fn kill_renderer_process_group(child: &Child) -> std::io::Result<()> {
+    let Some(pid) = child.id() else {
+        return Ok(());
+    };
+    // Renderers launch in their own process group; a negative PID addresses the full tree.
+    let result = unsafe { libc::kill(-(pid as i32), libc::SIGKILL) };
+    if result == -1 {
+        let error = std::io::Error::last_os_error();
+        if error.raw_os_error() != Some(libc::ESRCH) {
+            return Err(error);
+        }
+    }
+    Ok(())
+}
+
+async fn terminate_renderer(child: &mut Child) -> std::io::Result<()> {
+    #[cfg(unix)]
+    kill_renderer_process_group(child)?;
     #[cfg(windows)]
     if let Some(pid) = child.id() {
         let _ = Command::new("taskkill")
@@ -539,98 +586,6 @@ async fn terminate_renderer(child: &mut Child) -> std::io::Result<()> {
         let _ = child.start_kill();
     }
     child.wait().await.map(|_| ())
-}
-
-fn copy_directory(source: &Path, destination: &Path) -> std::io::Result<()> {
-    for entry in std::fs::read_dir(source)? {
-        let entry = entry?;
-        let file_type = entry.file_type()?;
-        if file_type.is_symlink() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::PermissionDenied,
-                "renderer bundle contains a symbolic link",
-            ));
-        }
-        let target = destination.join(entry.file_name());
-        if file_type.is_dir() {
-            std::fs::create_dir_all(&target)?;
-            copy_directory(&entry.path(), &target)?;
-        } else if file_type.is_file() {
-            std::fs::copy(entry.path(), target)?;
-        }
-    }
-    Ok(())
-}
-fn normalize_replay_bundle(directory: &Path) -> std::io::Result<()> {
-    let assets = directory.join("assets");
-    if assets.is_dir() {
-        let nested = assets.join("assets");
-        std::fs::create_dir_all(&nested)?;
-        for entry in std::fs::read_dir(&assets)? {
-            let entry = entry?;
-            if entry
-                .path()
-                .extension()
-                .is_some_and(|extension| extension == "png")
-            {
-                std::fs::copy(entry.path(), nested.join(entry.file_name()))?;
-            }
-        }
-    }
-    let app = directory.join("app.js");
-    if app.is_file() {
-        let content = std::fs::read_to_string(&app)?
-            .replace("from '../config.js'", "from './config.js'")
-            .replace("from '../demo.js'", "from './demo.js'")
-            .replace(
-                "viewerUrl: '/core/Drawer.js'",
-                "viewerUrl: './core/Drawer.js'",
-            );
-        std::fs::write(app, content)?;
-    }
-    Ok(())
-}
-
-fn replay_command(
-    referee: &RefereeConfig,
-    artifact_path: &Path,
-    session_directory: &Path,
-    port: u16,
-    participant_count: u8,
-) -> Result<Vec<String>, ReplayError> {
-    let RefereeConfig::Command(referee) = referee else {
-        return Err(ReplayError::InvalidCommand(
-            "codingame_jar replay rendering is not implemented".to_string(),
-        ));
-    };
-    let mut parts = shell_words::split(&referee.watch_replay)
-        .map_err(|error| ReplayError::InvalidCommand(error.to_string()))?;
-    if parts.is_empty() {
-        return Err(ReplayError::InvalidCommand(
-            "cmd_watch_replay must not be blank".to_string(),
-        ));
-    }
-
-    let port = port.to_string();
-    let participant_count = participant_count.to_string();
-    let replacements = [
-        ("{REPLAY_PATH}", artifact_path.to_str()),
-        ("{REPLAY_DIR}", session_directory.to_str()),
-        ("{PORT}", Some(port.as_str())),
-        ("{PLAYER_COUNT}", Some(participant_count.as_str())),
-    ];
-    for (placeholder, value) in replacements {
-        let value = value.ok_or_else(|| {
-            ReplayError::InvalidCommand(format!("{placeholder} value is not valid UTF-8"))
-        })?;
-        let Some(part) = parts.iter_mut().find(|part| part.as_str() == placeholder) else {
-            return Err(ReplayError::InvalidCommand(format!(
-                "cmd_watch_replay must contain {placeholder}"
-            )));
-        };
-        *part = value.to_string();
-    }
-    Ok(parts)
 }
 
 async fn available_local_port() -> Result<u16, ReplayError> {
@@ -726,6 +681,7 @@ mod tests {
             RefereeConfig::Command(crate::config::CommandRefereeConfig {
                 play_match: "true".to_string(),
                 watch_replay: command,
+                legacy: false,
             }),
             startup_timeout,
             Duration::from_secs(60),
@@ -951,7 +907,7 @@ exec sleep 30"#,
             codingame_fixture(
             "echo $$ > renderer.pid\nsleep 30 &\necho $! > renderer-child.pid\necho actionable-timeout >&2\nwait",
             r#"{"agents":[{},{}]}"#,
-            Duration::from_secs(1),
+            Duration::from_secs(3),
         )
         .await;
 
@@ -1030,6 +986,49 @@ exec sleep 30"#,
                 .starts_with(".jvm-")
         }));
     }
+
+    #[tokio::test]
+    async fn codingame_renderer_is_reaped_when_request_future_is_dropped() {
+        let (temporary_directory, viewer, artifact, session, _cancellation_token) =
+            codingame_fixture(
+                "echo $$ > renderer.pid\nsleep 30 &\necho $! > renderer-child.pid\nwait",
+                r#"{"agents":[{},{}]}"#,
+                Duration::from_secs(30),
+            )
+            .await;
+        let renderer_pid = temporary_directory
+            .path()
+            .join("codingame arena/renderer.pid");
+        let renderer_child_pid = temporary_directory
+            .path()
+            .join("codingame arena/renderer-child.pid");
+        let session_for_request = session.clone();
+        let request = tokio::spawn(async move {
+            viewer
+                .generate_bundle(&artifact, &session_for_request, 2)
+                .await
+        });
+        for _ in 0..200 {
+            if renderer_child_pid.exists() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(renderer_child_pid.exists(), "renderer did not start");
+
+        request.abort();
+        let _ = request.await;
+
+        assert_process_gone(&renderer_pid).await;
+        assert_process_gone(&renderer_child_pid).await;
+        assert!(!std::fs::read_dir(&session).unwrap().any(|entry| {
+            entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".jvm-")
+        }));
+    }
     #[tokio::test]
     async fn codingame_renderer_returns_early_stderr() {
         let (_temporary_directory, viewer, artifact, session, _cancellation_token) =
@@ -1064,41 +1063,42 @@ exec sleep 30"#,
 
     #[test]
     fn replay_command_preserves_quoted_paths_and_requires_contract() {
-        let command = replay_command(
-            &RefereeConfig::Command(crate::config::CommandRefereeConfig {
-                play_match: "true".to_string(),
-                watch_replay: "\"renderer path\" {REPLAY_PATH} {REPLAY_DIR} {PORT} {PLAYER_COUNT}"
-                    .to_string(),
-            }),
-            Path::new("/artifact path/replay.json"),
-            Path::new("/session path"),
-            12345,
-            4,
-        )
-        .unwrap();
+        let config = RefereeConfig::Command(crate::config::CommandRefereeConfig {
+            play_match: "true".to_string(),
+            watch_replay: "\"renderer path\" {REPLAY_PATH} {REPLAY_DIR} {PORT} {PLAYER_COUNT}"
+                .to_string(),
+            legacy: false,
+        });
+        let command = RefereeAdapter::from(&config)
+            .prepare_replay_command(
+                Path::new("/artifact path/replay.json"),
+                Path::new("/session path"),
+                Path::new("/unused"),
+                12345,
+                4,
+            )
+            .unwrap();
+        assert_eq!(command.program, "renderer path");
         assert_eq!(
-            command,
-            [
-                "renderer path",
-                "/artifact path/replay.json",
-                "/session path",
-                "12345",
-                "4",
-            ]
+            command.args,
+            ["/artifact path/replay.json", "/session path", "12345", "4",]
         );
 
-        assert!(matches!(
-            replay_command(
-                &RefereeConfig::Command(crate::config::CommandRefereeConfig {
-                    play_match: "true".to_string(),
-                    watch_replay: "renderer {REPLAY_PATH}".to_string(),
-                }),
-                Path::new("replay.json"),
-                Path::new("session"),
-                1,
-                2,
-            ),
-            Err(ReplayError::InvalidCommand(_))
-        ));
+        let incomplete = RefereeConfig::Command(crate::config::CommandRefereeConfig {
+            play_match: "true".to_string(),
+            watch_replay: "renderer {REPLAY_PATH}".to_string(),
+            legacy: false,
+        });
+        let result = RefereeAdapter::from(&incomplete).prepare_replay_command(
+            Path::new("replay.json"),
+            Path::new("session"),
+            Path::new("unused"),
+            1,
+            2,
+        );
+        let Err(error) = result else {
+            panic!("incomplete replay command must be rejected");
+        };
+        assert!(error.to_string().contains("{REPLAY_DIR}"));
     }
 }

--- a/src/replay_viewer.rs
+++ b/src/replay_viewer.rs
@@ -248,17 +248,23 @@ impl ReplayViewer {
         session_directory: &Path,
         participant_count: u8,
     ) -> Result<(), ReplayError> {
+        let artifact_path = fs::canonicalize(artifact_path)
+            .await
+            .map_err(|error| ReplayError::InvalidArtifact(error.to_string()))?;
+        let session_directory = fs::canonicalize(session_directory)
+            .await
+            .map_err(|error| ReplayError::Internal(error.to_string()))?;
         if matches!(self.inner.referee, RefereeConfig::CodingameJar(_)) {
             return self
-                .generate_codingame_bundle(artifact_path, session_directory, participant_count)
+                .generate_codingame_bundle(&artifact_path, &session_directory, participant_count)
                 .await;
         }
         let port = available_local_port().await?;
         let prepared = RefereeAdapter::from(&self.inner.referee)
             .prepare_replay_command(
-                artifact_path,
-                session_directory,
-                session_directory,
+                &artifact_path,
+                &session_directory,
+                &session_directory,
                 port,
                 participant_count,
             )
@@ -711,14 +717,29 @@ mod tests {
         replay: &str,
         startup_timeout: Duration,
     ) -> (TempDir, ReplayViewer, PathBuf, PathBuf, CancellationToken) {
-        let temporary_directory = tempfile::tempdir().unwrap();
-        let arena_path = temporary_directory.path().join("codingame arena");
-        fs::create_dir_all(&arena_path).await.unwrap();
-        let artifact_path = arena_path.join("replay.json");
-        fs::write(&artifact_path, replay).await.unwrap();
-        let session_directory = arena_path.join("session");
-        fs::create_dir_all(&session_directory).await.unwrap();
-        let launcher_path = arena_path.join("fake java.sh");
+        let current_directory = std::env::current_dir().unwrap();
+        let temporary_directory = tempfile::tempdir_in(&current_directory).unwrap();
+        let absolute_arena_path = temporary_directory.path().join("codingame arena");
+        fs::create_dir_all(&absolute_arena_path).await.unwrap();
+        let absolute_artifact_path = absolute_arena_path.join("replay.json");
+        fs::write(&absolute_artifact_path, replay).await.unwrap();
+        let absolute_session_directory = absolute_arena_path.join("session");
+        fs::create_dir_all(&absolute_session_directory)
+            .await
+            .unwrap();
+        let launcher_path = absolute_arena_path.join("fake java.sh");
+        let arena_path = absolute_arena_path
+            .strip_prefix(&current_directory)
+            .unwrap()
+            .to_path_buf();
+        let artifact_path = absolute_artifact_path
+            .strip_prefix(&current_directory)
+            .unwrap()
+            .to_path_buf();
+        let session_directory = absolute_session_directory
+            .strip_prefix(&current_directory)
+            .unwrap()
+            .to_path_buf();
         fs::write(
             &launcher_path,
             format!(

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -3,11 +3,14 @@ use crate::domain::{
     BotId, Build, BuildResult, Language, MatchAttribute, MatchAttributeValue, Participant,
     SourceCode, WorkerName,
 };
+use crate::referee_adapter::{
+    read_codingame_match_result, validate_match_result, MatchCommandAttribute as CmdMatchAttribute,
+    MatchCommandOutput as CmdPlayMatchStdout, MatchResultSource, PreparedMatchCommand,
+    RefereeAdapter,
+};
 use crate::replay_artifact::{PendingReplay, ProvisionalReplay};
 use anyhow::{bail, Context};
 use itertools::Itertools;
-use serde::Deserialize;
-use serde_json::Value;
 use std::collections::HashSet;
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -511,20 +514,13 @@ async fn execute_match(
     if cancellation_token.is_cancelled() {
         return Ok(None);
     }
-    let (command_parts, replay, codingame_jar) =
-        prepare_play_match_command(&config, &input, &worker_path)
+    let (command, replay) = prepare_play_match_command(&config, &input, &worker_path)
+        .await
+        .map_err(WorkerFailure::new)?;
+    let output =
+        spawn_play_match_command(command, replay, worker_path, &input, &cancellation_token)
             .await
-            .map_err(WorkerFailure::new)?;
-    let output = spawn_play_match_command(
-        command_parts,
-        replay,
-        codingame_jar,
-        worker_path,
-        &input,
-        &cancellation_token,
-    )
-    .await
-    .map_err(|error| WorkerFailure::new(format!("{error:#}")))?;
+            .map_err(|error| WorkerFailure::new(format!("{error:#}")))?;
     Ok(output.map(|output| Completion::Match { input, output }))
 }
 
@@ -688,7 +684,7 @@ async fn prepare_play_match_command(
     config: &EmbeddedWorkerConfig,
     input: &PlayMatchInput,
     worker_path: &Path,
-) -> anyhow::Result<(Vec<String>, Option<ProvisionalReplay>, bool)> {
+) -> anyhow::Result<(PreparedMatchCommand, Option<ProvisionalReplay>)> {
     let run_commands = input
         .bots
         .iter()
@@ -704,107 +700,60 @@ async fn prepare_play_match_command(
                 .replace("{LANG}", &bot.language))
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
-
-    let template = match &config.referee {
-        RefereeConfig::Command(referee) => shell_words::split(&referee.play_match)
-            .context("invalid command referee play_match quoting")?,
-        RefereeConfig::CodingameJar(referee) => {
-            let replay = ProvisionalReplay::create(worker_path).await?;
-            let replay_path = replay
-                .command_path()
-                .to_str()
-                .context("replay path must be UTF-8")?;
-            let mut command = vec![
-                referee.java.clone().unwrap_or_else(|| "java".to_string()),
-                "--add-opens".to_string(),
-                "java.base/java.lang=ALL-UNNAMED".to_string(),
-                "-jar".to_string(),
-                referee.path.clone(),
-            ];
-            for (index, player) in run_commands.iter().enumerate() {
-                command.push(format!("-p{}", index + 1));
-                command.push(player.clone());
-            }
-            command.extend([
-                "-seed".to_string(),
-                input.seed.to_string(),
-                "-league".to_string(),
-                referee.league.unwrap_or(19).to_string(),
-                "-l".to_string(),
-                replay_path.to_string(),
-            ]);
-            return Ok((command, Some(replay), true));
-        }
-    };
-
-    let replay = if template.iter().any(|part| part == "{REPLAY_PATH}") {
+    let adapter = RefereeAdapter::from(&config.referee);
+    let replay = if adapter.match_replay_required() {
         Some(ProvisionalReplay::create(worker_path).await?)
     } else {
         None
     };
-    let replay_path_value = replay
-        .as_ref()
-        .map(ProvisionalReplay::command_path)
-        .and_then(Path::to_str)
-        .context("replay path must be UTF-8")
-        .or_else(|error| if replay.is_none() { Ok("") } else { Err(error) })?;
-    let seed = input.seed.to_string();
-    let mut command_parts = Vec::new();
-    for part in template {
-        match part.as_str() {
-            "{SEED}" => command_parts.push(seed.clone()),
-            "{PLAYERS}" => command_parts.extend(run_commands.iter().cloned()),
-            "{REPLAY_PATH}" => command_parts.push(replay_path_value.to_string()),
-            _ => {
-                let player = part
-                    .strip_prefix("{P")
-                    .and_then(|value| value.strip_suffix('}'))
-                    .and_then(|value| value.parse::<usize>().ok());
-                if let Some(player) = player {
-                    command_parts.push(
-                        run_commands
-                            .get(player.saturating_sub(1))
-                            .with_context(|| format!("command referee references missing {part}"))?
-                            .clone(),
-                    );
-                } else {
-                    command_parts.push(part);
-                }
-            }
-        }
-    }
-    Ok((command_parts, replay, false))
+    let command = adapter.prepare_match_command(
+        input.seed,
+        &run_commands,
+        replay.as_ref().map(ProvisionalReplay::command_path),
+    )?;
+    Ok((command, replay))
 }
 
 async fn spawn_play_match_command(
-    command_parts: Vec<String>,
+    command: PreparedMatchCommand,
     replay: Option<ProvisionalReplay>,
-    codingame_jar: bool,
     worker_path: PathBuf,
     input: &PlayMatchInput,
     cancellation_token: &CancellationToken,
 ) -> anyhow::Result<Option<PlayMatchOutput>> {
-    let Some(cmd_output) = run_command(command_parts, &worker_path, cancellation_token).await?
+    let result_source = command.result_source;
+    let Some(cmd_output) = run_command(command.argv, &worker_path, cancellation_token).await?
     else {
         return Ok(None);
     };
     if !cmd_output.status.success() {
+        let stderr = String::from_utf8_lossy(&cmd_output.stderr);
+        let stdout = String::from_utf8_lossy(&cmd_output.stdout);
+        let diagnostic = if stderr.trim().is_empty() {
+            stdout.trim()
+        } else {
+            stderr.trim()
+        };
         bail!(
-            "Error while running match: {}",
-            String::from_utf8_lossy(&cmd_output.stderr)
+            "Error while running match ({}): {}",
+            cmd_output.status,
+            diagnostic
         );
     }
-    let result = if codingame_jar {
-        codingame_result(
-            replay
-                .as_ref()
-                .context("codingame referee did not receive replay artifact")?
-                .command_path(),
-            input.bots.len(),
-        )?
-    } else {
-        serde_json::from_slice::<CmdPlayMatchStdout>(&cmd_output.stdout)
-            .context("play match output should be valid JSON")?
+    let result = match result_source {
+        MatchResultSource::CodingameReplay => {
+            let replay_path = worker_path.join(
+                replay
+                    .as_ref()
+                    .context("codingame referee did not receive replay artifact")?
+                    .command_path(),
+            );
+            read_codingame_match_result(&replay_path, input.bots.len())?
+        }
+        MatchResultSource::CommandStdout => {
+            serde_json::from_slice::<CmdPlayMatchStdout>(&cmd_output.stdout)
+                .context("play match output should be valid JSON")?
+        }
     };
     validate_match_result(&result, input.bots.len())?;
     let replay = match replay {
@@ -845,91 +794,6 @@ async fn spawn_play_match_command(
     }))
 }
 
-fn codingame_result(path: &Path, player_count: usize) -> anyhow::Result<CmdPlayMatchStdout> {
-    let replay: Value = serde_json::from_slice(&std::fs::read(path)?)
-        .context("codingame replay artifact must be valid JSON")?;
-    let score_map = replay
-        .get("scores")
-        .and_then(Value::as_object)
-        .context("codingame replay artifact has no scores object")?;
-    if score_map.len() != player_count {
-        bail!(
-            "codingame replay has {} scores for {player_count} bots",
-            score_map.len()
-        );
-    }
-    let scores = (0..player_count)
-        .map(|index| {
-            score_map
-                .get(&index.to_string())
-                .and_then(Value::as_i64)
-                .context("codingame replay score is not an integer")
-                .and_then(|score| {
-                    i32::try_from(score).context("codingame replay score is out of range")
-                })
-        })
-        .collect::<anyhow::Result<Vec<_>>>()?;
-    let mut attributes = Vec::new();
-    if let Some(errors) = replay.get("errors").and_then(Value::as_object) {
-        for player in 0..player_count {
-            for line in errors
-                .get(&player.to_string())
-                .and_then(Value::as_array)
-                .into_iter()
-                .flatten()
-                .filter_map(Value::as_str)
-                .flat_map(str::lines)
-            {
-                if let Some(attribute) = parse_codingame_attribute(line, player) {
-                    attributes.push(attribute);
-                }
-            }
-        }
-    }
-    Ok(CmdPlayMatchStdout {
-        ranks: scores
-            .iter()
-            .map(|score| scores.iter().filter(|other| score < *other).count() as u8)
-            .collect(),
-        errors: scores.iter().map(|score| u8::from(*score < 0)).collect(),
-        scores,
-        attributes,
-    })
-}
-
-fn parse_codingame_attribute(line: &str, player: usize) -> Option<CmdMatchAttribute> {
-    let line = line.trim();
-    let (owner, rest) = if let Some(rest) = line.strip_prefix("[TDATA]") {
-        (None, rest)
-    } else if let Some(rest) = line.strip_prefix("[PDATA]") {
-        (Some(player), rest)
-    } else {
-        return None;
-    };
-    let rest = rest.trim_start();
-    let (turn, rest) = if let Some(rest) = rest.strip_prefix('[') {
-        let (turn, rest) = rest.split_once(']')?;
-        (Some(turn.parse().ok()?), rest)
-    } else {
-        (None, rest)
-    };
-    let (name, value) = rest.trim().split_once('=')?;
-    let name = name.trim();
-    if name.is_empty()
-        || !name
-            .chars()
-            .all(|character| character.is_alphanumeric() || character == '_')
-    {
-        return None;
-    }
-    Some(CmdMatchAttribute {
-        name: name.to_string(),
-        player: owner,
-        turn,
-        value: value.trim().to_string(),
-    })
-}
-
 #[derive(Clone)]
 pub struct BuildBotInput {
     pub bot_id: BotId,
@@ -963,45 +827,6 @@ pub struct PlayMatchOutput {
     pub replay: PendingReplay,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct CmdPlayMatchStdout {
-    #[serde(default)]
-    pub scores: Vec<i32>,
-    pub ranks: Vec<u8>,
-    pub errors: Vec<u8>,
-    #[serde(default)]
-    pub attributes: Vec<CmdMatchAttribute>,
-}
-
-#[derive(Debug, Deserialize, Default)]
-pub struct CmdMatchAttribute {
-    pub name: String,
-    pub player: Option<usize>,
-    pub turn: Option<u16>,
-    pub value: String,
-}
-
-fn validate_match_result(result: &CmdPlayMatchStdout, bot_count: usize) -> anyhow::Result<()> {
-    if result.ranks.len() != bot_count || result.errors.len() != bot_count {
-        bail!("play match output must contain ranks and errors for {bot_count} bots");
-    }
-    if !result.scores.is_empty() && result.scores.len() != bot_count {
-        bail!(
-            "play match output has {} scores for {bot_count} bots",
-            result.scores.len()
-        );
-    }
-    if let Some(player) = result
-        .attributes
-        .iter()
-        .filter_map(|attribute| attribute.player)
-        .find(|player| *player >= bot_count)
-    {
-        bail!("play match output references missing player {player}");
-    }
-    Ok(())
-}
-
 fn to_match_attribute(input: &PlayMatchInput, attr: CmdMatchAttribute) -> MatchAttribute {
     let bot_id = attr.player.map(|p| input.bots[p].bot_id);
 
@@ -1025,6 +850,8 @@ mod tests {
             referee: RefereeConfig::Command(crate::config::CommandRefereeConfig {
                 play_match: cmd_play_match,
                 watch_replay: "true".to_string(),
+
+                legacy: false,
             }),
             cmd_build,
             cmd_run: "true".to_string(),
@@ -1035,6 +862,17 @@ mod tests {
         let path = directory.join(name);
         fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
         format!("sh {}", shell_words::quote(&path.to_string_lossy()))
+    }
+    #[cfg(unix)]
+    fn executable_script(directory: &Path, name: &str, body: &str) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = directory.join(name);
+        fs::write(&path, format!("#!/bin/sh\nset -eu\n{body}\n")).unwrap();
+        let mut permissions = fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&path, permissions).unwrap();
+        path
     }
 
     fn build_input(bot_id: i64) -> BuildBotInput {
@@ -1224,12 +1062,16 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let input = match_input(42);
         let command_config = config("true".to_string(), "runner {P1} {P2} {SEED}".to_string());
-        let (command, _, codingame) =
+        let (command, replay) =
             prepare_play_match_command(&command_config, &input, directory.path())
                 .await
                 .unwrap();
-        assert_eq!(command, ["runner", "true", "true", "42"]);
-        assert!(!codingame);
+        assert_eq!(command.argv, ["runner", "true", "true", "42"]);
+        assert!(matches!(
+            command.result_source,
+            MatchResultSource::CommandStdout
+        ));
+        assert!(replay.is_none());
 
         let jar_config = EmbeddedWorkerConfig {
             threads: 1,
@@ -1241,14 +1083,16 @@ mod tests {
             cmd_build: "true".to_string(),
             cmd_run: "run {DIR} --language {LANG}".to_string(),
         };
-        let (command, replay, codingame) =
-            prepare_play_match_command(&jar_config, &input, directory.path())
-                .await
-                .unwrap();
-        assert!(codingame);
+        let (command, replay) = prepare_play_match_command(&jar_config, &input, directory.path())
+            .await
+            .unwrap();
+        assert!(matches!(
+            command.result_source,
+            MatchResultSource::CodingameReplay
+        ));
         assert!(replay.is_some());
         assert_eq!(
-            &command[..12],
+            &command.argv[..12],
             [
                 "java",
                 "--add-opens",
@@ -1264,7 +1108,101 @@ mod tests {
                 "-league",
             ]
         );
-        assert_eq!(command[12], "7");
+        assert_eq!(command.argv[12], "7");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn codingame_adapter_runs_match_and_preserves_observable_contract() {
+        let directory = tempfile::tempdir().unwrap();
+        let java = executable_script(
+            directory.path(),
+            "fake-java.sh",
+            r#"replay=''
+player_one=''
+player_two=''
+seed=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -p1) player_one="$2"; shift 2 ;;
+    -p2) player_two="$2"; shift 2 ;;
+    -seed) seed="$2"; shift 2 ;;
+    -l) replay="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+test "$player_one" = "run bots/1 --language rust"
+test "$player_two" = "run bots/2 --language rust"
+test "$seed" = "73"
+printf '%s\n' '{"scores":{"0":9,"1":4},"errors":{"0":[null,"[tdata] rounds = 3"],"1":[null]}}' > "$replay""#,
+        );
+        let config = EmbeddedWorkerConfig {
+            threads: 1,
+            referee: RefereeConfig::CodingameJar(crate::config::CodingameJarRefereeConfig {
+                path: "fixture.jar".to_string(),
+                java: Some(java.to_string_lossy().to_string()),
+                league: None,
+            }),
+            cmd_build: "true".to_string(),
+            cmd_run: "run {DIR} --language {LANG}".to_string(),
+        };
+        let StartedWorker { worker, supervisor } =
+            start_embedded_worker(directory.path(), config).unwrap();
+
+        worker.submit(Work::Match(match_input(73))).await.unwrap();
+        let Completion::Match { input, output } = worker.next().await.unwrap() else {
+            panic!("expected a match completion");
+        };
+
+        assert_eq!(input.seed, 73);
+        assert_eq!(output.participants[0].rank, 0);
+        assert!(!output.participants[0].error);
+        assert_eq!(output.participants[1].rank, 1);
+        assert_eq!(
+            output
+                .attributes
+                .iter()
+                .find(|attribute| attribute.name == "rounds")
+                .and_then(|attribute| attribute.value.integer_value()),
+            Some(3)
+        );
+        assert_eq!(
+            fs::read_dir(directory.path().join("replays"))
+                .unwrap()
+                .count(),
+            1
+        );
+        supervisor.shutdown().await.unwrap();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn codingame_adapter_reports_nonzero_status_and_stdout_diagnostic() {
+        let directory = tempfile::tempdir().unwrap();
+        let java = executable_script(
+            directory.path(),
+            "failing-java.sh",
+            "echo actionable-on-stdout\nexit 7",
+        );
+        let config = EmbeddedWorkerConfig {
+            threads: 1,
+            referee: RefereeConfig::CodingameJar(crate::config::CodingameJarRefereeConfig {
+                path: "fixture.jar".to_string(),
+                java: Some(java.to_string_lossy().to_string()),
+                league: None,
+            }),
+            cmd_build: "true".to_string(),
+            cmd_run: "true".to_string(),
+        };
+        let StartedWorker { worker, supervisor } =
+            start_embedded_worker(directory.path(), config).unwrap();
+
+        worker.submit(Work::Match(match_input(9))).await.unwrap();
+        let failure = supervisor.failed().await;
+
+        assert!(failure.to_string().contains("exit status: 7"));
+        assert!(failure.to_string().contains("actionable-on-stdout"));
+        assert!(supervisor.shutdown().await.is_err());
     }
 
     #[test]
@@ -1277,23 +1215,25 @@ mod tests {
                 "scores": {"0": 10, "1": -1},
                 "errors": {
                     "0": [null, "[TDATA][12] map_size = 16\n[PDATA] final_score = 10"],
-                    "1": [null]
+                    "1": [null, "[pdata] lower_case = kept"]
                 }
             }"#,
         )
         .unwrap();
 
-        let result = codingame_result(&replay, 2).unwrap();
+        let result = read_codingame_match_result(&replay, 2).unwrap();
 
         assert_eq!(result.scores, [10, -1]);
         assert_eq!(result.ranks, [0, 1]);
         assert_eq!(result.errors, [0, 1]);
-        assert_eq!(result.attributes.len(), 2);
+        assert_eq!(result.attributes.len(), 3);
         assert_eq!(result.attributes[0].name, "map_size");
         assert_eq!(result.attributes[0].player, None);
         assert_eq!(result.attributes[0].turn, Some(12));
         assert_eq!(result.attributes[1].name, "final_score");
         assert_eq!(result.attributes[1].player, Some(0));
+        assert_eq!(result.attributes[2].name, "lower_case");
+        assert_eq!(result.attributes[2].player, Some(1));
     }
 
     #[test]
@@ -1302,7 +1242,7 @@ mod tests {
         let replay = directory.path().join("replay.json");
         fs::write(&replay, r#"{"scores":{"0":10},"errors":{}}"#).unwrap();
 
-        let error = codingame_result(&replay, 2).unwrap_err();
+        let error = read_codingame_match_result(&replay, 2).unwrap_err();
 
         assert!(error.to_string().contains("1 scores for 2 bots"));
     }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -806,10 +806,7 @@ async fn spawn_play_match_command(
         serde_json::from_slice::<CmdPlayMatchStdout>(&cmd_output.stdout)
             .context("play match output should be valid JSON")?
     };
-    let bot_count = input.bots.len();
-    if result.ranks.len() != bot_count || result.errors.len() != bot_count {
-        bail!("play match output must contain ranks and errors for {bot_count} bots");
-    }
+    validate_match_result(&result, input.bots.len())?;
     let replay = match replay {
         Some(replay) => replay.finish().await?,
         None => PendingReplay::default(),
@@ -851,14 +848,44 @@ async fn spawn_play_match_command(
 fn codingame_result(path: &Path, player_count: usize) -> anyhow::Result<CmdPlayMatchStdout> {
     let replay: Value = serde_json::from_slice(&std::fs::read(path)?)
         .context("codingame replay artifact must be valid JSON")?;
+    let score_map = replay
+        .get("scores")
+        .and_then(Value::as_object)
+        .context("codingame replay artifact has no scores object")?;
+    if score_map.len() != player_count {
+        bail!(
+            "codingame replay has {} scores for {player_count} bots",
+            score_map.len()
+        );
+    }
     let scores = (0..player_count)
         .map(|index| {
-            replay["scores"][index.to_string()]
-                .as_i64()
+            score_map
+                .get(&index.to_string())
+                .and_then(Value::as_i64)
                 .context("codingame replay score is not an integer")
-                .map(|score| score as i32)
+                .and_then(|score| {
+                    i32::try_from(score).context("codingame replay score is out of range")
+                })
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
+    let mut attributes = Vec::new();
+    if let Some(errors) = replay.get("errors").and_then(Value::as_object) {
+        for player in 0..player_count {
+            for line in errors
+                .get(&player.to_string())
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(Value::as_str)
+                .flat_map(str::lines)
+            {
+                if let Some(attribute) = parse_codingame_attribute(line, player) {
+                    attributes.push(attribute);
+                }
+            }
+        }
+    }
     Ok(CmdPlayMatchStdout {
         ranks: scores
             .iter()
@@ -866,7 +893,40 @@ fn codingame_result(path: &Path, player_count: usize) -> anyhow::Result<CmdPlayM
             .collect(),
         errors: scores.iter().map(|score| u8::from(*score < 0)).collect(),
         scores,
-        attributes: vec![],
+        attributes,
+    })
+}
+
+fn parse_codingame_attribute(line: &str, player: usize) -> Option<CmdMatchAttribute> {
+    let line = line.trim();
+    let (owner, rest) = if let Some(rest) = line.strip_prefix("[TDATA]") {
+        (None, rest)
+    } else if let Some(rest) = line.strip_prefix("[PDATA]") {
+        (Some(player), rest)
+    } else {
+        return None;
+    };
+    let rest = rest.trim_start();
+    let (turn, rest) = if let Some(rest) = rest.strip_prefix('[') {
+        let (turn, rest) = rest.split_once(']')?;
+        (Some(turn.parse().ok()?), rest)
+    } else {
+        (None, rest)
+    };
+    let (name, value) = rest.trim().split_once('=')?;
+    let name = name.trim();
+    if name.is_empty()
+        || !name
+            .chars()
+            .all(|character| character.is_alphanumeric() || character == '_')
+    {
+        return None;
+    }
+    Some(CmdMatchAttribute {
+        name: name.to_string(),
+        player: owner,
+        turn,
+        value: value.trim().to_string(),
     })
 }
 
@@ -903,7 +963,7 @@ pub struct PlayMatchOutput {
     pub replay: PendingReplay,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct CmdPlayMatchStdout {
     #[serde(default)]
     pub scores: Vec<i32>,
@@ -913,12 +973,33 @@ pub struct CmdPlayMatchStdout {
     pub attributes: Vec<CmdMatchAttribute>,
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Debug, Deserialize, Default)]
 pub struct CmdMatchAttribute {
     pub name: String,
     pub player: Option<usize>,
     pub turn: Option<u16>,
     pub value: String,
+}
+
+fn validate_match_result(result: &CmdPlayMatchStdout, bot_count: usize) -> anyhow::Result<()> {
+    if result.ranks.len() != bot_count || result.errors.len() != bot_count {
+        bail!("play match output must contain ranks and errors for {bot_count} bots");
+    }
+    if !result.scores.is_empty() && result.scores.len() != bot_count {
+        bail!(
+            "play match output has {} scores for {bot_count} bots",
+            result.scores.len()
+        );
+    }
+    if let Some(player) = result
+        .attributes
+        .iter()
+        .filter_map(|attribute| attribute.player)
+        .find(|player| *player >= bot_count)
+    {
+        bail!("play match output references missing player {player}");
+    }
+    Ok(())
 }
 
 fn to_match_attribute(input: &PlayMatchInput, attr: CmdMatchAttribute) -> MatchAttribute {
@@ -1137,6 +1218,126 @@ mod tests {
                 .count(),
             0
         );
+    }
+    #[tokio::test]
+    async fn referee_adapters_preserve_player_argument_contracts() {
+        let directory = tempfile::tempdir().unwrap();
+        let input = match_input(42);
+        let command_config = config("true".to_string(), "runner {P1} {P2} {SEED}".to_string());
+        let (command, _, codingame) =
+            prepare_play_match_command(&command_config, &input, directory.path())
+                .await
+                .unwrap();
+        assert_eq!(command, ["runner", "true", "true", "42"]);
+        assert!(!codingame);
+
+        let jar_config = EmbeddedWorkerConfig {
+            threads: 1,
+            referee: RefereeConfig::CodingameJar(crate::config::CodingameJarRefereeConfig {
+                path: "referee.jar".to_string(),
+                java: None,
+                league: Some(7),
+            }),
+            cmd_build: "true".to_string(),
+            cmd_run: "run {DIR} --language {LANG}".to_string(),
+        };
+        let (command, replay, codingame) =
+            prepare_play_match_command(&jar_config, &input, directory.path())
+                .await
+                .unwrap();
+        assert!(codingame);
+        assert!(replay.is_some());
+        assert_eq!(
+            &command[..12],
+            [
+                "java",
+                "--add-opens",
+                "java.base/java.lang=ALL-UNNAMED",
+                "-jar",
+                "referee.jar",
+                "-p1",
+                "run bots/1 --language rust",
+                "-p2",
+                "run bots/2 --language rust",
+                "-seed",
+                "42",
+                "-league",
+            ]
+        );
+        assert_eq!(command[12], "7");
+    }
+
+    #[test]
+    fn codingame_replay_conversion_preserves_results_and_attributes() {
+        let directory = tempfile::tempdir().unwrap();
+        let replay = directory.path().join("replay.json");
+        fs::write(
+            &replay,
+            r#"{
+                "scores": {"0": 10, "1": -1},
+                "errors": {
+                    "0": [null, "[TDATA][12] map_size = 16\n[PDATA] final_score = 10"],
+                    "1": [null]
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let result = codingame_result(&replay, 2).unwrap();
+
+        assert_eq!(result.scores, [10, -1]);
+        assert_eq!(result.ranks, [0, 1]);
+        assert_eq!(result.errors, [0, 1]);
+        assert_eq!(result.attributes.len(), 2);
+        assert_eq!(result.attributes[0].name, "map_size");
+        assert_eq!(result.attributes[0].player, None);
+        assert_eq!(result.attributes[0].turn, Some(12));
+        assert_eq!(result.attributes[1].name, "final_score");
+        assert_eq!(result.attributes[1].player, Some(0));
+    }
+
+    #[test]
+    fn codingame_replay_conversion_rejects_wrong_score_count() {
+        let directory = tempfile::tempdir().unwrap();
+        let replay = directory.path().join("replay.json");
+        fs::write(&replay, r#"{"scores":{"0":10},"errors":{}}"#).unwrap();
+
+        let error = codingame_result(&replay, 2).unwrap_err();
+
+        assert!(error.to_string().contains("1 scores for 2 bots"));
+    }
+
+    #[test]
+    fn command_result_rejects_wrong_score_count() {
+        let result = CmdPlayMatchStdout {
+            scores: vec![10],
+            ranks: vec![0, 1],
+            errors: vec![0, 0],
+            attributes: Vec::new(),
+        };
+
+        let error = validate_match_result(&result, 2).unwrap_err();
+
+        assert!(error.to_string().contains("1 scores for 2 bots"));
+    }
+
+    #[test]
+    fn command_result_rejects_attribute_for_missing_player() {
+        let result = CmdPlayMatchStdout {
+            scores: Vec::new(),
+            ranks: vec![0, 1],
+            errors: vec![0, 0],
+            attributes: vec![CmdMatchAttribute {
+                name: "score".to_string(),
+                player: Some(2),
+                turn: None,
+                value: "10".to_string(),
+            }],
+        };
+
+        let error = validate_match_result(&result, 2).unwrap_err();
+
+        assert!(error.to_string().contains("missing player 2"));
     }
 
     #[tokio::test]

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,4 +1,4 @@
-use crate::config::EmbeddedWorkerConfig;
+use crate::config::{EmbeddedWorkerConfig, RefereeConfig};
 use crate::domain::{
     BotId, Build, BuildResult, Language, MatchAttribute, MatchAttributeValue, Participant,
     SourceCode, WorkerName,
@@ -7,6 +7,7 @@ use crate::replay_artifact::{PendingReplay, ProvisionalReplay};
 use anyhow::{bail, Context};
 use itertools::Itertools;
 use serde::Deserialize;
+use serde_json::Value;
 use std::collections::HashSet;
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -510,12 +511,14 @@ async fn execute_match(
     if cancellation_token.is_cancelled() {
         return Ok(None);
     }
-    let (command_parts, replay) = prepare_play_match_command(&config, &input, &worker_path)
-        .await
-        .map_err(WorkerFailure::new)?;
+    let (command_parts, replay, codingame_jar) =
+        prepare_play_match_command(&config, &input, &worker_path)
+            .await
+            .map_err(WorkerFailure::new)?;
     let output = spawn_play_match_command(
         command_parts,
         replay,
+        codingame_jar,
         worker_path,
         &input,
         &cancellation_token,
@@ -685,7 +688,7 @@ async fn prepare_play_match_command(
     config: &EmbeddedWorkerConfig,
     input: &PlayMatchInput,
     worker_path: &Path,
-) -> anyhow::Result<(Vec<String>, Option<ProvisionalReplay>)> {
+) -> anyhow::Result<(Vec<String>, Option<ProvisionalReplay>, bool)> {
     let run_commands = input
         .bots
         .iter()
@@ -702,11 +705,37 @@ async fn prepare_play_match_command(
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
 
-    let template =
-        shell_words::split(&config.cmd_play_match).context("invalid cmd_play_match quoting")?;
-    if template.is_empty() {
-        bail!("cmd_play_match must not be blank");
-    }
+    let template = match &config.referee {
+        RefereeConfig::Command(referee) => shell_words::split(&referee.play_match)
+            .context("invalid command referee play_match quoting")?,
+        RefereeConfig::CodingameJar(referee) => {
+            let replay = ProvisionalReplay::create(worker_path).await?;
+            let replay_path = replay
+                .command_path()
+                .to_str()
+                .context("replay path must be UTF-8")?;
+            let mut command = vec![
+                referee.java.clone().unwrap_or_else(|| "java".to_string()),
+                "--add-opens".to_string(),
+                "java.base/java.lang=ALL-UNNAMED".to_string(),
+                "-jar".to_string(),
+                referee.path.clone(),
+            ];
+            for (index, player) in run_commands.iter().enumerate() {
+                command.push(format!("-p{}", index + 1));
+                command.push(player.clone());
+            }
+            command.extend([
+                "-seed".to_string(),
+                input.seed.to_string(),
+                "-league".to_string(),
+                referee.league.unwrap_or(19).to_string(),
+                "-l".to_string(),
+                replay_path.to_string(),
+            ]);
+            return Ok((command, Some(replay), true));
+        }
+    };
 
     let replay = if template.iter().any(|part| part == "{REPLAY_PATH}") {
         Some(ProvisionalReplay::create(worker_path).await?)
@@ -721,35 +750,36 @@ async fn prepare_play_match_command(
         .or_else(|error| if replay.is_none() { Ok("") } else { Err(error) })?;
     let seed = input.seed.to_string();
     let mut command_parts = Vec::new();
-
     for part in template {
         match part.as_str() {
             "{SEED}" => command_parts.push(seed.clone()),
             "{PLAYERS}" => command_parts.extend(run_commands.iter().cloned()),
             "{REPLAY_PATH}" => command_parts.push(replay_path_value.to_string()),
             _ => {
-                let player_index = part
+                let player = part
                     .strip_prefix("{P")
                     .and_then(|value| value.strip_suffix('}'))
                     .and_then(|value| value.parse::<usize>().ok());
-                if let Some(player_index) = player_index {
-                    let command = run_commands
-                        .get(player_index.saturating_sub(1))
-                        .with_context(|| format!("cmd_play_match references missing {part}"))?;
-                    command_parts.push(command.clone());
+                if let Some(player) = player {
+                    command_parts.push(
+                        run_commands
+                            .get(player.saturating_sub(1))
+                            .with_context(|| format!("command referee references missing {part}"))?
+                            .clone(),
+                    );
                 } else {
                     command_parts.push(part);
                 }
             }
         }
     }
-
-    Ok((command_parts, replay))
+    Ok((command_parts, replay, false))
 }
 
 async fn spawn_play_match_command(
     command_parts: Vec<String>,
     replay: Option<ProvisionalReplay>,
+    codingame_jar: bool,
     worker_path: PathBuf,
     input: &PlayMatchInput,
     cancellation_token: &CancellationToken,
@@ -758,51 +788,32 @@ async fn spawn_play_match_command(
     else {
         return Ok(None);
     };
-
-    let result = if cmd_output.status.success() {
-        let stdout = String::from_utf8(cmd_output.stdout).context("stdout is not valid UTF-8")?;
-        serde_json::from_str::<CmdPlayMatchStdout>(&stdout)
-            .context("play match output should be valid JSON")?
-    } else {
+    if !cmd_output.status.success() {
         bail!(
             "Error while running match: {}",
-            String::from_utf8(cmd_output.stderr).context("stderr is not valid UTF-8")?
+            String::from_utf8_lossy(&cmd_output.stderr)
         );
+    }
+    let result = if codingame_jar {
+        codingame_result(
+            replay
+                .as_ref()
+                .context("codingame referee did not receive replay artifact")?
+                .command_path(),
+            input.bots.len(),
+        )?
+    } else {
+        serde_json::from_slice::<CmdPlayMatchStdout>(&cmd_output.stdout)
+            .context("play match output should be valid JSON")?
     };
-
     let bot_count = input.bots.len();
-    if result.ranks.len() != bot_count {
-        bail!(
-            "play match output has {} ranks for {bot_count} bots",
-            result.ranks.len()
-        );
+    if result.ranks.len() != bot_count || result.errors.len() != bot_count {
+        bail!("play match output must contain ranks and errors for {bot_count} bots");
     }
-    if result.errors.len() != bot_count {
-        bail!(
-            "play match output has {} errors for {bot_count} bots",
-            result.errors.len()
-        );
-    }
-    if !result.scores.is_empty() && result.scores.len() != bot_count {
-        bail!(
-            "play match output has {} scores for {bot_count} bots",
-            result.scores.len()
-        );
-    }
-    if let Some(player) = result
-        .attributes
-        .iter()
-        .filter_map(|attribute| attribute.player)
-        .find(|player| *player >= bot_count)
-    {
-        bail!("play match output references missing player {player}");
-    }
-
     let replay = match replay {
         Some(replay) => replay.finish().await?,
         None => PendingReplay::default(),
     };
-
     Ok(Some(PlayMatchOutput {
         seed: input.seed,
         participants: input
@@ -820,9 +831,7 @@ async fn spawn_play_match_command(
             .attributes
             .into_iter()
             .map(|attribute| to_match_attribute(input, attribute))
-            .chain(if result.scores.is_empty() {
-                vec![].into_iter()
-            } else {
+            .chain(
                 input
                     .bots
                     .iter()
@@ -832,13 +841,33 @@ async fn spawn_play_match_command(
                         bot_id: Some(bot.bot_id),
                         turn: None,
                         value: MatchAttributeValue::Integer(score as _),
-                    })
-                    .collect_vec()
-                    .into_iter()
-            })
+                    }),
+            )
             .collect(),
         replay,
     }))
+}
+
+fn codingame_result(path: &Path, player_count: usize) -> anyhow::Result<CmdPlayMatchStdout> {
+    let replay: Value = serde_json::from_slice(&std::fs::read(path)?)
+        .context("codingame replay artifact must be valid JSON")?;
+    let scores = (0..player_count)
+        .map(|index| {
+            replay["scores"][index.to_string()]
+                .as_i64()
+                .context("codingame replay score is not an integer")
+                .map(|score| score as i32)
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    Ok(CmdPlayMatchStdout {
+        ranks: scores
+            .iter()
+            .map(|score| scores.iter().filter(|other| score < *other).count() as u8)
+            .collect(),
+        errors: scores.iter().map(|score| u8::from(*score < 0)).collect(),
+        scores,
+        attributes: vec![],
+    })
 }
 
 #[derive(Clone)]
@@ -912,8 +941,10 @@ mod tests {
     fn config(cmd_build: String, cmd_play_match: String) -> EmbeddedWorkerConfig {
         EmbeddedWorkerConfig {
             threads: 1,
-            cmd_play_match,
-            cmd_watch_replay: "true".to_string(),
+            referee: RefereeConfig::Command(crate::config::CommandRefereeConfig {
+                play_match: cmd_play_match,
+                watch_replay: "true".to_string(),
+            }),
             cmd_build,
             cmd_run: "true".to_string(),
         }


### PR DESCRIPTION
## Summary

- add explicit `codingame_jar` and `command` referee adapters behind a centralized adapter seam
- invoke compatible CodinGame JARs directly for match results and isolated static replay extraction
- probe the versioned `--cgarena-compat` / `cgarena-referee-v1` contract before matchmaking
- reap renderer process trees on success, failure, timeout, shutdown, and dropped replay requests
- transparently migrate legacy flat command configuration and preserve the existing SQLx database migration chain
- resolve referee and replay paths correctly for both absolute and relative arena paths
- make the JAR adapter the generated default and stop generating Python launcher scripts

Closes #21
Closes #22
Closes #23

## Verification

- `cargo test` — 103 passed
- maintained `CommandLineInterface.java` compiled with `javac`
- real compatible JAR probe returned `cgarena-referee-v1`
- real two-player compatible-JAR match forwarded seed `17` and wrote a replay with two agents/scores
- real compatible-JAR replay renderer generated `test.html`; renderer was then stopped
- final parallel standards/spec reviews: no remaining findings
