### PR TITLE
Launch new arenas into first-run setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,4 @@ libc = "0.2"
 [dev-dependencies]
 tempfile = "3.20"
 assert_float_eq = "1.1.4"
+tower = { version = "0.5", features = ["util"] }

--- a/assets/bootstrap_config.toml
+++ b/assets/bootstrap_config.toml
@@ -1,0 +1,10 @@
+# Settings required before the configuration UI is available.
+[server]
+# Omit or set to 0 to let the OS assign an available port.
+port = 1234
+# Expose only on a trusted local network; CG Arena has no authentication.
+expose = false
+
+[log]
+level = "INFO"
+file = "cgarena.log"

--- a/cg-arena-ui/src/App.tsx
+++ b/cg-arena-ui/src/App.tsx
@@ -1,17 +1,36 @@
 import "./App.css";
 
+import * as api from "@/api";
 import AppNavbar from "@/components/AppNavbar";
 import DialogsProvider from "@/components/DialogsProvider";
+import { configurationQueryKey } from "@/configuration";
+import ConfigPage from "@/pages/ConfigPage";
+import { useQuery } from "@tanstack/react-query";
 import { Outlet } from "@tanstack/react-router";
-import { Container } from "react-bootstrap";
+import { Alert, Container, Spinner } from "react-bootstrap";
 
 function App() {
+  const configuration = useQuery({
+    queryKey: configurationQueryKey,
+    queryFn: api.fetchConfiguration,
+  });
+  const runtimeAvailable = configuration.data?.runtime_available === true;
+
+  let content;
+  if (configuration.isPending) {
+    content = <Spinner animation="border" aria-label="Loading application" />;
+  } else if (configuration.error) {
+    content = <Alert variant="danger">{configuration.error.message}</Alert>;
+  } else if (!runtimeAvailable) {
+    content = <ConfigPage />;
+  } else {
+    content = <Outlet />;
+  }
+
   return (
     <DialogsProvider>
-      <AppNavbar />
-      <Container className="py-4">
-        <Outlet />
-      </Container>
+      <AppNavbar runtimeAvailable={runtimeAvailable} />
+      <Container className="py-4">{content}</Container>
     </DialogsProvider>
   );
 }

--- a/cg-arena-ui/src/api/index.ts
+++ b/cg-arena-ui/src/api/index.ts
@@ -14,6 +14,8 @@ import {
   EnableMatchmakingRequest,
   MatchId,
   WatchReplayResponse,
+  ArenaConfiguration,
+  ConfigurationState,
 } from "@/models";
 
 const host = import.meta.env.DEV ? "http://127.0.0.1:1234" : "";
@@ -21,6 +23,24 @@ const host = import.meta.env.DEV ? "http://127.0.0.1:1234" : "";
 export const fetchStatus = async (): Promise<FetchStatusResponse> => {
   const response = await fetch(`${host}/api/status`);
   return await parseResponse<FetchStatusResponse>(response);
+};
+
+export const fetchConfiguration = async (): Promise<ConfigurationState> => {
+  const response = await fetch(`${host}/api/configuration`);
+  return await parseResponse<ConfigurationState>(response);
+};
+
+export const applyConfiguration = async (
+  payload: ArenaConfiguration,
+): Promise<ConfigurationState> => {
+  const response = await fetch(
+    new Request(`${host}/api/configuration`, {
+      method: "PUT",
+      body: JSON.stringify(payload),
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+  return await parseResponse<ConfigurationState>(response);
 };
 
 export const submitNewBot = async (
@@ -150,12 +170,18 @@ export const closeReplay = async (sessionId: string) => {
 };
 
 async function checkForErrors(response: Response) {
-  if (response.status >= 500) {
-    throw new Error("Internal server error");
-  } else if (!response.ok) {
-    const body = (await response.json()) as ApiErrorResponse;
-    throw new Error(body.message ?? body.error_code);
+  if (response.ok) {
+    return;
   }
+
+  let message = response.statusText || `HTTP ${response.status}`;
+  try {
+    const body = (await response.json()) as ApiErrorResponse;
+    message = body.message ?? body.error_code ?? message;
+  } catch {
+    // Keep the HTTP status when the server does not return its JSON error shape.
+  }
+  throw new Error(message);
 }
 
 async function parseResponse<T>(response: Response): Promise<T> {

--- a/cg-arena-ui/src/components/AppNavbar.tsx
+++ b/cg-arena-ui/src/components/AppNavbar.tsx
@@ -13,7 +13,7 @@ import { useDialogs } from "@/hooks/useDialogs";
 import { useAppStore } from "@/hooks/useAppStore";
 import { Link } from "@tanstack/react-router";
 
-function AppNavbar() {
+function AppNavbar({ runtimeAvailable }: { runtimeAvailable: boolean }) {
   const { submitBotDialog } = useDialogs();
   const loading = useAppStore((state) => state.loading);
   const status = useAppStore((state) => state.status);
@@ -24,8 +24,8 @@ function AppNavbar() {
   const openSubmitDialog = () => {
     submitBotDialog.show({ onSubmit: submitNewBot });
   };
-  const pillBg = status == "connected" ? "success" : "warning";
-  const pillText = status == "connected" ? "light" : "dark";
+  const connected = runtimeAvailable && status === "connected";
+  const statusText = runtimeAvailable ? status : "setup";
 
   return (
     <Navbar className="bg-body-tertiary">
@@ -40,35 +40,47 @@ function AppNavbar() {
         <Navbar.Toggle aria-controls="basic-navbar-nav" />
         <Navbar.Collapse id="basic-navbar-nav">
           <Nav className="me-auto">
-            <Link
-              to="/"
-              className="nav-link"
-              search={(prev) => ({ selectedBotId: prev.selectedBotId })}
-            >
-              Home
-            </Link>
-            <Link to="/matches" className="nav-link">
-              Matches
-            </Link>
-            {/* <Link to="/config" className="nav-link">
+            {runtimeAvailable && (
+              <>
+                <Link
+                  to="/"
+                  className="nav-link"
+                  search={(prev) => ({ selectedBotId: prev.selectedBotId })}
+                >
+                  Home
+                </Link>
+                <Link to="/matches" className="nav-link">
+                  Matches
+                </Link>
+              </>
+            )}
+            <Link to="/config" className="nav-link">
               Config
-            </Link> */}
+            </Link>
           </Nav>
         </Navbar.Collapse>
 
         <Stack direction="horizontal" gap={3}>
           {loading && <Spinner animation="border" />}
-          <Badge pill bg={pillBg} text={pillText}>
-            {status}
+          <Badge
+            pill
+            bg={connected ? "success" : "warning"}
+            text={connected ? "light" : "dark"}
+          >
+            {statusText}
           </Badge>
-          <Form.Switch
-            checked={matchmakingEnabled}
-            onChange={(e) => enableMatchmaking(e.target.checked)}
-            label="Matchmaking"
-          />
-          <Button variant="primary" onClick={openSubmitDialog}>
-            Submit a new bot
-          </Button>
+          {runtimeAvailable && (
+            <>
+              <Form.Switch
+                checked={matchmakingEnabled}
+                onChange={(event) => enableMatchmaking(event.target.checked)}
+                label="Matchmaking"
+              />
+              <Button variant="primary" onClick={openSubmitDialog}>
+                Submit a new bot
+              </Button>
+            </>
+          )}
           <ThemeSwitcher />
         </Stack>
       </Container>

--- a/cg-arena-ui/src/configuration.ts
+++ b/cg-arena-ui/src/configuration.ts
@@ -1,0 +1,8 @@
+import { ArenaConfiguration, ConfigurationState } from "@/models";
+
+export interface ConfigurationAdapter {
+  fetch(): Promise<ConfigurationState>;
+  apply(candidate: ArenaConfiguration): Promise<ConfigurationState>;
+}
+
+export const configurationQueryKey = ["configuration"] as const;

--- a/cg-arena-ui/src/models/index.ts
+++ b/cg-arena-ui/src/models/index.ts
@@ -1,3 +1,78 @@
+export interface ConfigurationState {
+  active: ArenaConfiguration | null;
+  runtime_available: boolean;
+}
+
+export interface ArenaConfiguration {
+  game: GameConfiguration;
+  matchmaking: MatchmakingConfiguration;
+  ranking: RankingConfiguration;
+  leaderboards: LeaderboardsConfiguration;
+  workers: EmbeddedWorkerConfiguration[];
+}
+
+export interface GameConfiguration {
+  min_players: number;
+  max_players: number;
+  symmetric: boolean;
+  referee_git_url: string | null;
+}
+
+export type MatchmakingConfiguration =
+  | {
+      algorithm: "v1";
+      min_matches: number;
+      min_matches_preference: number;
+      enabled_on_start: boolean | null;
+    }
+  | {
+      algorithm: "v2";
+      min_matches_against_best: number | null;
+      min_matches_per_pair: number;
+      max_matches: number | null;
+      enabled_on_start: boolean | null;
+    };
+
+export type RankingConfiguration =
+  | {
+      algorithm: "OpenSkill";
+      beta: number | null;
+      uncertainty_tolerance: number | null;
+    }
+  | {
+      algorithm: "TrueSkill";
+      draw_probability: number | null;
+      beta: number | null;
+      default_dynamics: number | null;
+    }
+  | { algorithm: "Elo"; k: number | null }
+  | { algorithm: "BradleyTerry"; max_iter: number | null };
+
+export interface LeaderboardsConfiguration {
+  uncertainty_coefficient: number | null;
+}
+
+export interface EmbeddedWorkerConfiguration {
+  type: "embedded";
+  threads: number;
+  referee: RefereeConfiguration;
+  cmd_build: string;
+  cmd_run: string;
+}
+
+export type RefereeConfiguration =
+  | {
+      type: "codingame_jar";
+      path: string;
+      java: string | null;
+      league: number | null;
+    }
+  | {
+      type: "command";
+      play_match: string;
+      watch_replay: string;
+    };
+
 export interface CreateBotRequest {
   name: string;
   source_code: string;

--- a/cg-arena-ui/src/pages/ConfigPage.test.tsx
+++ b/cg-arena-ui/src/pages/ConfigPage.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { PropsWithChildren } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ConfigurationAdapter } from "@/configuration";
+import { ArenaConfiguration, ConfigurationState } from "@/models";
+import ConfigPage from "./ConfigPage";
+
+class InMemoryConfigurationAdapter implements ConfigurationAdapter {
+  readonly applied: ArenaConfiguration[] = [];
+
+  constructor(
+    private state: ConfigurationState,
+    private readonly applyError?: Error,
+  ) {}
+
+  async fetch(): Promise<ConfigurationState> {
+    return this.state;
+  }
+
+  async apply(candidate: ArenaConfiguration): Promise<ConfigurationState> {
+    this.applied.push(candidate);
+    if (this.applyError) {
+      throw this.applyError;
+    }
+    this.state = { active: candidate, runtime_available: false };
+    return this.state;
+  }
+}
+
+function renderPage(adapter: ConfigurationAdapter) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return render(<ConfigPage adapter={adapter} />, { wrapper });
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("first-run configuration page", () => {
+  it("edits and atomically applies one complete arena configuration", async () => {
+    const adapter = new InMemoryConfigurationAdapter({
+      active: null,
+      runtime_available: false,
+    });
+    renderPage(adapter);
+
+    expect(
+      await screen.findByRole("heading", { name: "Set up your arena" }),
+    ).toBeTruthy();
+    for (const section of [
+      "Game",
+      "Matchmaking",
+      "Ranking and leaderboard",
+      "Embedded worker",
+      "Referee",
+    ]) {
+      expect(screen.getByText(section)).toBeTruthy();
+    }
+
+    fireEvent.change(screen.getByLabelText("Minimum players"), {
+      target: { value: "3" },
+    });
+    fireEvent.change(screen.getByLabelText("Maximum players"), {
+      target: { value: "4" },
+    });
+    fireEvent.change(screen.getByLabelText("Worker threads"), {
+      target: { value: "2" },
+    });
+    fireEvent.change(screen.getByLabelText("Ranking algorithm"), {
+      target: { value: "Elo" },
+    });
+    fireEvent.change(screen.getByLabelText("Elo K-factor"), {
+      target: { value: "24" },
+    });
+    fireEvent.change(screen.getByLabelText("Play-match command"), {
+      target: {
+        value: "my-referee {SEED} {REPLAY_PATH} {PLAYERS}",
+      },
+    });
+    fireEvent.change(screen.getByLabelText("Watch-replay command"), {
+      target: {
+        value: "my-renderer {REPLAY_PATH} {REPLAY_DIR} {PORT} {PLAYER_COUNT}",
+      },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Apply configuration" }),
+    );
+
+    await waitFor(() => expect(adapter.applied).toHaveLength(1));
+    expect(adapter.applied[0]).toMatchObject({
+      game: { min_players: 3, max_players: 4, symmetric: true },
+      matchmaking: { algorithm: "v2", enabled_on_start: true },
+      ranking: { algorithm: "Elo", k: 24 },
+      workers: [
+        {
+          type: "embedded",
+          threads: 2,
+          referee: { type: "command" },
+        },
+      ],
+    });
+    expect(
+      await screen.findByText(
+        /Configuration saved as the active configuration/,
+      ),
+    ).toBeTruthy();
+  });
+
+  it("shows server validation errors without replacing the draft", async () => {
+    const adapter = new InMemoryConfigurationAdapter(
+      { active: null, runtime_available: false },
+      new Error(
+        "Validation failed: command referee play_match must contain {SEED}",
+      ),
+    );
+    renderPage(adapter);
+
+    const playMatch = await screen.findByLabelText("Play-match command");
+    fireEvent.change(playMatch, { target: { value: "broken command" } });
+    fireEvent.change(screen.getByLabelText("Watch-replay command"), {
+      target: {
+        value:
+          "my-renderer {REPLAY_PATH} {REPLAY_DIR} {PORT} {PLAYER_COUNT}",
+      },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Apply configuration" }),
+    );
+
+    expect(
+      await screen.findByText(
+        "Validation failed: command referee play_match must contain {SEED}",
+      ),
+    ).toBeTruthy();
+    expect(adapter.applied).toHaveLength(1);
+    expect(
+      (screen.getByLabelText("Play-match command") as HTMLInputElement).value,
+    ).toBe("broken command");
+    expect(
+      screen.queryByText(/Configuration saved as the active configuration/),
+    ).toBeNull();
+  });
+});

--- a/cg-arena-ui/src/pages/ConfigPage.tsx
+++ b/cg-arena-ui/src/pages/ConfigPage.tsx
@@ -1,9 +1,801 @@
-import { Alert } from "react-bootstrap";
+import * as api from "@/api";
+import { ConfigurationAdapter, configurationQueryKey } from "@/configuration";
+import {
+  ArenaConfiguration,
+  ConfigurationState,
+  EmbeddedWorkerConfiguration,
+  MatchmakingConfiguration,
+  RankingConfiguration,
+  RefereeConfiguration,
+} from "@/models";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { FormEvent, useState } from "react";
+import {
+  Alert,
+  Button,
+  Card,
+  Col,
+  Form,
+  Row,
+  Spinner,
+  Stack,
+} from "react-bootstrap";
 
-export default function ConfigPage() {
+const httpAdapter: ConfigurationAdapter = {
+  fetch: api.fetchConfiguration,
+  apply: api.applyConfiguration,
+};
+
+function defaultConfiguration(): ArenaConfiguration {
+  return {
+    game: {
+      min_players: 2,
+      max_players: 2,
+      symmetric: true,
+      referee_git_url: null,
+    },
+    matchmaking: {
+      algorithm: "v2",
+      min_matches_against_best: null,
+      min_matches_per_pair: 100,
+      max_matches: 1000,
+      enabled_on_start: true,
+    },
+    ranking: { algorithm: "BradleyTerry", max_iter: null },
+    leaderboards: { uncertainty_coefficient: null },
+    workers: [
+      {
+        type: "embedded",
+        threads: 1,
+        cmd_build: "g++ -std=c++20 -x c++ {DIR}/source.txt -o {DIR}/a",
+        cmd_run: "./{DIR}/a",
+        referee: {
+          type: "command",
+          play_match: "",
+          watch_replay: "",
+        },
+      },
+    ],
+  };
+}
+
+function optionalNumber(value: string): number | null {
+  return value === "" ? null : Number(value);
+}
+
+interface ConfigPageProps {
+  adapter?: ConfigurationAdapter;
+}
+
+export default function ConfigPage({ adapter = httpAdapter }: ConfigPageProps) {
+  const configuration = useQuery({
+    queryKey: configurationQueryKey,
+    queryFn: () => adapter.fetch(),
+  });
+
+  if (configuration.isPending) {
+    return <Spinner animation="border" aria-label="Loading configuration" />;
+  }
+  if (configuration.error) {
+    return <Alert variant="danger">{configuration.error.message}</Alert>;
+  }
+
   return (
-    <Alert variant="secondary">
-      Configuration editor is not available yet.
-    </Alert>
+    <ConfigurationForm adapter={adapter} initialState={configuration.data} />
+  );
+}
+
+function ConfigurationForm({
+  adapter,
+  initialState,
+}: {
+  adapter: ConfigurationAdapter;
+  initialState: ConfigurationState;
+}) {
+  const queryClient = useQueryClient();
+  const [state, setState] = useState(initialState);
+  const [draft, setDraft] = useState<ArenaConfiguration>(
+    initialState.active ?? defaultConfiguration(),
+  );
+  const [saved, setSaved] = useState(false);
+  const apply = useMutation({
+    mutationFn: (candidate: ArenaConfiguration) => adapter.apply(candidate),
+    onSuccess: (nextState) => {
+      queryClient.setQueryData(configurationQueryKey, nextState);
+      setState(nextState);
+      setDraft(nextState.active ?? draft);
+      setSaved(true);
+    },
+  });
+
+  const firstRun = state.active === null;
+  const worker = draft.workers[0];
+
+  const setWorker = (next: Partial<EmbeddedWorkerConfiguration>) => {
+    setDraft((current) => ({
+      ...current,
+      workers: [{ ...current.workers[0], ...next }],
+    }));
+    setSaved(false);
+  };
+
+  const updateCommandReferee = (
+    next: Partial<{ play_match: string; watch_replay: string }>,
+  ) => {
+    if (worker.referee.type === "command") {
+      setWorker({ referee: { ...worker.referee, ...next } });
+    }
+  };
+
+  const updateJarReferee = (
+    next: Partial<{ path: string; java: string | null; league: number | null }>,
+  ) => {
+    if (worker.referee.type === "codingame_jar") {
+      setWorker({ referee: { ...worker.referee, ...next } });
+    }
+  };
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault();
+    setSaved(false);
+    apply.mutate(draft);
+  };
+
+  return (
+    <Stack gap={3}>
+      <div>
+        <h1>{firstRun ? "Set up your arena" : "Arena configuration"}</h1>
+        <p className="text-body-secondary mb-0">
+          Apply one complete configuration. Server and logging settings remain
+          in cgarena_config.toml and require a restart.
+        </p>
+      </div>
+
+      {firstRun && (
+        <Alert variant="info">
+          The server is ready, but matches and replays stay unavailable until a
+          valid arena configuration and its runtime prerequisites are active.
+        </Alert>
+      )}
+      {saved && (
+        <Alert variant="success">
+          Configuration saved as the active configuration.
+          {!state.runtime_available &&
+            " Runtime features are still unavailable in this process."}
+        </Alert>
+      )}
+      {apply.error && <Alert variant="danger">{apply.error.message}</Alert>}
+
+      <Form onSubmit={submit}>
+        <Stack gap={3}>
+          <Card>
+            <Card.Body>
+              <Card.Title>Game</Card.Title>
+              <Row className="g-3">
+                <Col md={4}>
+                  <Form.Group controlId="min-players">
+                    <Form.Label>Minimum players</Form.Label>
+                    <Form.Control
+                      type="number"
+                      min={1}
+                      max={8}
+                      required
+                      value={draft.game.min_players}
+                      onChange={(event) =>
+                        setDraft((current) => ({
+                          ...current,
+                          game: {
+                            ...current.game,
+                            min_players: Number(event.target.value),
+                          },
+                        }))
+                      }
+                    />
+                  </Form.Group>
+                </Col>
+                <Col md={4}>
+                  <Form.Group controlId="max-players">
+                    <Form.Label>Maximum players</Form.Label>
+                    <Form.Control
+                      type="number"
+                      min={1}
+                      max={8}
+                      required
+                      value={draft.game.max_players}
+                      onChange={(event) =>
+                        setDraft((current) => ({
+                          ...current,
+                          game: {
+                            ...current.game,
+                            max_players: Number(event.target.value),
+                          },
+                        }))
+                      }
+                    />
+                  </Form.Group>
+                </Col>
+                <Col md={4} className="d-flex align-items-end">
+                  <Form.Check
+                    id="symmetric-game"
+                    type="switch"
+                    label="Symmetric game"
+                    checked={draft.game.symmetric}
+                    onChange={(event) =>
+                      setDraft((current) => ({
+                        ...current,
+                        game: {
+                          ...current.game,
+                          symmetric: event.target.checked,
+                        },
+                      }))
+                    }
+                  />
+                </Col>
+              </Row>
+            </Card.Body>
+          </Card>
+
+          <Card>
+            <Card.Body>
+              <Card.Title>Matchmaking</Card.Title>
+              <Row className="g-3">
+                <Col md={4}>
+                  <Form.Group controlId="matchmaking-algorithm">
+                    <Form.Label>Algorithm</Form.Label>
+                    <Form.Select
+                      value={draft.matchmaking.algorithm}
+                      onChange={(event) => {
+                        const next: MatchmakingConfiguration =
+                          event.target.value === "v1"
+                            ? {
+                                algorithm: "v1",
+                                min_matches: 100,
+                                min_matches_preference: 1,
+                                enabled_on_start:
+                                  draft.matchmaking.enabled_on_start,
+                              }
+                            : {
+                                algorithm: "v2",
+                                min_matches_against_best: null,
+                                min_matches_per_pair: 100,
+                                max_matches: 1000,
+                                enabled_on_start:
+                                  draft.matchmaking.enabled_on_start,
+                              };
+                        setDraft((current) => ({
+                          ...current,
+                          matchmaking: next,
+                        }));
+                      }}
+                    >
+                      <option value="v1">V1</option>
+                      <option value="v2">V2</option>
+                    </Form.Select>
+                  </Form.Group>
+                </Col>
+                {draft.matchmaking.algorithm === "v1" ? (
+                  <>
+                    <Col md={4}>
+                      <Form.Group controlId="minimum-matches">
+                        <Form.Label>Minimum matches</Form.Label>
+                        <Form.Control
+                          type="number"
+                          min={0}
+                          required
+                          value={draft.matchmaking.min_matches}
+                          onChange={(event) =>
+                            setDraft((current) => ({
+                              ...current,
+                              matchmaking: {
+                                ...current.matchmaking,
+                                min_matches: Number(event.target.value),
+                              } as MatchmakingConfiguration,
+                            }))
+                          }
+                        />
+                      </Form.Group>
+                    </Col>
+                    <Col md={4}>
+                      <Form.Group controlId="minimum-matches-preference">
+                        <Form.Label>Minimum matches preference</Form.Label>
+                        <Form.Control
+                          type="number"
+                          min={0}
+                          max={1}
+                          step="any"
+                          required
+                          value={draft.matchmaking.min_matches_preference}
+                          onChange={(event) =>
+                            setDraft((current) => ({
+                              ...current,
+                              matchmaking: {
+                                ...current.matchmaking,
+                                min_matches_preference: Number(
+                                  event.target.value,
+                                ),
+                              } as MatchmakingConfiguration,
+                            }))
+                          }
+                        />
+                      </Form.Group>
+                    </Col>
+                  </>
+                ) : (
+                  <>
+                    <Col md={4}>
+                      <Form.Group controlId="minimum-matches-per-pair">
+                        <Form.Label>Minimum matches per pair</Form.Label>
+                        <Form.Control
+                          type="number"
+                          min={0}
+                          required
+                          value={draft.matchmaking.min_matches_per_pair}
+                          onChange={(event) =>
+                            setDraft((current) => ({
+                              ...current,
+                              matchmaking: {
+                                ...current.matchmaking,
+                                min_matches_per_pair: Number(
+                                  event.target.value,
+                                ),
+                              } as MatchmakingConfiguration,
+                            }))
+                          }
+                        />
+                      </Form.Group>
+                    </Col>
+                    <Col md={4}>
+                      <Form.Group controlId="maximum-matches">
+                        <Form.Label>Maximum matches</Form.Label>
+                        <Form.Control
+                          type="number"
+                          min={0}
+                          value={draft.matchmaking.max_matches ?? ""}
+                          onChange={(event) =>
+                            setDraft((current) => ({
+                              ...current,
+                              matchmaking: {
+                                ...current.matchmaking,
+                                max_matches: optionalNumber(event.target.value),
+                              } as MatchmakingConfiguration,
+                            }))
+                          }
+                        />
+                      </Form.Group>
+                    </Col>
+                    <Col md={4}>
+                      <Form.Group controlId="matches-against-best">
+                        <Form.Label>Matches against best</Form.Label>
+                        <Form.Control
+                          type="number"
+                          min={0}
+                          value={
+                            draft.matchmaking.min_matches_against_best ?? ""
+                          }
+                          onChange={(event) =>
+                            setDraft((current) => ({
+                              ...current,
+                              matchmaking: {
+                                ...current.matchmaking,
+                                min_matches_against_best: optionalNumber(
+                                  event.target.value,
+                                ),
+                              } as MatchmakingConfiguration,
+                            }))
+                          }
+                        />
+                      </Form.Group>
+                    </Col>
+                  </>
+                )}
+                <Col xs={12}>
+                  <Form.Check
+                    id="start-matchmaking"
+                    type="switch"
+                    label="Start matchmaking automatically"
+                    checked={draft.matchmaking.enabled_on_start ?? true}
+                    onChange={(event) =>
+                      setDraft((current) => ({
+                        ...current,
+                        matchmaking: {
+                          ...current.matchmaking,
+                          enabled_on_start: event.target.checked,
+                        } as MatchmakingConfiguration,
+                      }))
+                    }
+                  />
+                </Col>
+              </Row>
+            </Card.Body>
+          </Card>
+
+          <Card>
+            <Card.Body>
+              <Card.Title>Ranking and leaderboard</Card.Title>
+              <Row className="g-3">
+                <Col md={6}>
+                  <Form.Group controlId="ranking-algorithm">
+                    <Form.Label>Ranking algorithm</Form.Label>
+                    <Form.Select
+                      value={draft.ranking.algorithm}
+                      onChange={(event) => {
+                        const algorithms: Record<string, RankingConfiguration> =
+                          {
+                            OpenSkill: {
+                              algorithm: "OpenSkill",
+                              beta: null,
+                              uncertainty_tolerance: null,
+                            },
+                            TrueSkill: {
+                              algorithm: "TrueSkill",
+                              draw_probability: null,
+                              beta: null,
+                              default_dynamics: null,
+                            },
+                            Elo: { algorithm: "Elo", k: null },
+                            BradleyTerry: {
+                              algorithm: "BradleyTerry",
+                              max_iter: null,
+                            },
+                          };
+                        setDraft((current) => ({
+                          ...current,
+                          ranking: algorithms[event.target.value],
+                        }));
+                      }}
+                    >
+                      <option value="OpenSkill">OpenSkill</option>
+                      <option value="TrueSkill">TrueSkill</option>
+                      <option value="Elo">Elo</option>
+                      <option value="BradleyTerry">Bradley–Terry</option>
+                    </Form.Select>
+                  </Form.Group>
+                </Col>
+                <Col md={6}>
+                  <Form.Group controlId="uncertainty-coefficient">
+                    <Form.Label>Leaderboard uncertainty coefficient</Form.Label>
+                    <Form.Control
+                      type="number"
+                      step="any"
+                      placeholder="Default: 3"
+                      value={draft.leaderboards.uncertainty_coefficient ?? ""}
+                      onChange={(event) =>
+                        setDraft((current) => ({
+                          ...current,
+                          leaderboards: {
+                            uncertainty_coefficient: optionalNumber(
+                              event.target.value,
+                            ),
+                          },
+                        }))
+                      }
+                    />
+                  </Form.Group>
+                </Col>
+                {draft.ranking.algorithm === "OpenSkill" && (
+                  <>
+                    <OptionalNumberField
+                      id="openskill-beta"
+                      label="OpenSkill beta"
+                      value={draft.ranking.beta}
+                      onChange={(beta) =>
+                        setDraft((current) => ({
+                          ...current,
+                          ranking: {
+                            ...current.ranking,
+                            beta,
+                          } as RankingConfiguration,
+                        }))
+                      }
+                    />
+                    <OptionalNumberField
+                      id="uncertainty-tolerance"
+                      label="Uncertainty tolerance"
+                      value={draft.ranking.uncertainty_tolerance}
+                      onChange={(uncertainty_tolerance) =>
+                        setDraft((current) => ({
+                          ...current,
+                          ranking: {
+                            ...current.ranking,
+                            uncertainty_tolerance,
+                          } as RankingConfiguration,
+                        }))
+                      }
+                    />
+                  </>
+                )}
+                {draft.ranking.algorithm === "TrueSkill" && (
+                  <>
+                    <OptionalNumberField
+                      id="draw-probability"
+                      label="Draw probability"
+                      value={draft.ranking.draw_probability}
+                      onChange={(draw_probability) =>
+                        setDraft((current) => ({
+                          ...current,
+                          ranking: {
+                            ...current.ranking,
+                            draw_probability,
+                          } as RankingConfiguration,
+                        }))
+                      }
+                    />
+                    <OptionalNumberField
+                      id="trueskill-beta"
+                      label="TrueSkill beta"
+                      value={draft.ranking.beta}
+                      onChange={(beta) =>
+                        setDraft((current) => ({
+                          ...current,
+                          ranking: {
+                            ...current.ranking,
+                            beta,
+                          } as RankingConfiguration,
+                        }))
+                      }
+                    />
+                    <OptionalNumberField
+                      id="default-dynamics"
+                      label="Default dynamics"
+                      value={draft.ranking.default_dynamics}
+                      onChange={(default_dynamics) =>
+                        setDraft((current) => ({
+                          ...current,
+                          ranking: {
+                            ...current.ranking,
+                            default_dynamics,
+                          } as RankingConfiguration,
+                        }))
+                      }
+                    />
+                  </>
+                )}
+                {draft.ranking.algorithm === "Elo" && (
+                  <OptionalNumberField
+                    id="elo-k"
+                    label="Elo K-factor"
+                    value={draft.ranking.k}
+                    onChange={(k) =>
+                      setDraft((current) => ({
+                        ...current,
+                        ranking: {
+                          ...current.ranking,
+                          k,
+                        } as RankingConfiguration,
+                      }))
+                    }
+                  />
+                )}
+                {draft.ranking.algorithm === "BradleyTerry" && (
+                  <OptionalNumberField
+                    id="maximum-iterations"
+                    label="Maximum iterations"
+                    value={draft.ranking.max_iter}
+                    onChange={(max_iter) =>
+                      setDraft((current) => ({
+                        ...current,
+                        ranking: {
+                          ...current.ranking,
+                          max_iter,
+                        } as RankingConfiguration,
+                      }))
+                    }
+                  />
+                )}
+              </Row>
+            </Card.Body>
+          </Card>
+
+          <Card>
+            <Card.Body>
+              <Card.Title>Embedded worker</Card.Title>
+              <Row className="g-3">
+                <Col md={3}>
+                  <Form.Group controlId="worker-threads">
+                    <Form.Label>Worker threads</Form.Label>
+                    <Form.Control
+                      type="number"
+                      min={1}
+                      max={255}
+                      required
+                      value={worker.threads}
+                      onChange={(event) =>
+                        setWorker({ threads: Number(event.target.value) })
+                      }
+                    />
+                  </Form.Group>
+                </Col>
+                <Col md={9}>
+                  <Form.Group controlId="build-command">
+                    <Form.Label>Bot build command</Form.Label>
+                    <Form.Control
+                      required
+                      value={worker.cmd_build}
+                      onChange={(event) =>
+                        setWorker({ cmd_build: event.target.value })
+                      }
+                    />
+                  </Form.Group>
+                </Col>
+                <Col xs={12}>
+                  <Form.Group controlId="run-command">
+                    <Form.Label>Bot run command</Form.Label>
+                    <Form.Control
+                      required
+                      value={worker.cmd_run}
+                      onChange={(event) =>
+                        setWorker({ cmd_run: event.target.value })
+                      }
+                    />
+                  </Form.Group>
+                </Col>
+              </Row>
+            </Card.Body>
+          </Card>
+
+          <Card>
+            <Card.Body>
+              <Card.Title>Referee</Card.Title>
+              <Row className="g-3">
+                <Col md={4}>
+                  <Form.Group controlId="referee-type">
+                    <Form.Label>Adapter</Form.Label>
+                    <Form.Select
+                      value={worker.referee.type}
+                      onChange={(event) => {
+                        const referee: RefereeConfiguration =
+                          event.target.value === "codingame_jar"
+                            ? {
+                                type: "codingame_jar",
+                                path: "referee/target/referee.jar",
+                                java: null,
+                                league: null,
+                              }
+                            : {
+                                type: "command",
+                                play_match:
+                                  "my-referee {SEED} {REPLAY_PATH} {PLAYERS}",
+                                watch_replay:
+                                  "my-renderer {REPLAY_PATH} {REPLAY_DIR} {PORT} {PLAYER_COUNT}",
+                              };
+                        setWorker({ referee });
+                      }}
+                    >
+                      <option value="command">Custom commands</option>
+                      <option value="codingame_jar">
+                        Compatible CodinGame JAR
+                      </option>
+                    </Form.Select>
+                  </Form.Group>
+                </Col>
+                {worker.referee.type === "command" ? (
+                  <>
+                    <Col xs={12}>
+                      <Form.Group controlId="play-match-command">
+                        <Form.Label>Play-match command</Form.Label>
+                        <Form.Control
+                          required
+                          value={worker.referee.play_match}
+                          onChange={(event) =>
+                            updateCommandReferee({
+                              play_match: event.target.value,
+                            })
+                          }
+                        />
+                      </Form.Group>
+                    </Col>
+                    <Col xs={12}>
+                      <Form.Group controlId="watch-replay-command">
+                        <Form.Label>Watch-replay command</Form.Label>
+                        <Form.Control
+                          required
+                          value={worker.referee.watch_replay}
+                          onChange={(event) =>
+                            updateCommandReferee({
+                              watch_replay: event.target.value,
+                            })
+                          }
+                        />
+                      </Form.Group>
+                    </Col>
+                  </>
+                ) : (
+                  <>
+                    <Col md={8}>
+                      <Form.Group controlId="referee-jar-path">
+                        <Form.Label>Compatible JAR path</Form.Label>
+                        <Form.Control
+                          required
+                          value={worker.referee.path}
+                          onChange={(event) =>
+                            updateJarReferee({ path: event.target.value })
+                          }
+                        />
+                      </Form.Group>
+                    </Col>
+                    <OptionalTextField
+                      id="java-command"
+                      label="Java executable"
+                      value={worker.referee.java}
+                      placeholder="java"
+                      onChange={(java) => updateJarReferee({ java })}
+                    />
+                    <OptionalNumberField
+                      id="league"
+                      label="League"
+                      value={worker.referee.league}
+                      onChange={(league) => updateJarReferee({ league })}
+                    />
+                  </>
+                )}
+              </Row>
+            </Card.Body>
+          </Card>
+
+          <div>
+            <Button type="submit" disabled={apply.isPending}>
+              {apply.isPending ? "Applying…" : "Apply configuration"}
+            </Button>
+          </div>
+        </Stack>
+      </Form>
+    </Stack>
+  );
+}
+
+interface OptionalNumberFieldProps {
+  id: string;
+  label: string;
+  value: number | null;
+  onChange(value: number | null): void;
+}
+
+function OptionalNumberField({
+  id,
+  label,
+  value,
+  onChange,
+}: OptionalNumberFieldProps) {
+  return (
+    <Col md={4}>
+      <Form.Group controlId={id}>
+        <Form.Label>{label}</Form.Label>
+        <Form.Control
+          type="number"
+          step="any"
+          value={value ?? ""}
+          onChange={(event) => onChange(optionalNumber(event.target.value))}
+        />
+      </Form.Group>
+    </Col>
+  );
+}
+
+interface OptionalTextFieldProps {
+  id: string;
+  label: string;
+  value: string | null;
+  placeholder?: string;
+  onChange(value: string | null): void;
+}
+
+function OptionalTextField({
+  id,
+  label,
+  value,
+  placeholder,
+  onChange,
+}: OptionalTextFieldProps) {
+  return (
+    <Col md={4}>
+      <Form.Group controlId={id}>
+        <Form.Label>{label}</Form.Label>
+        <Form.Control
+          value={value ?? ""}
+          placeholder={placeholder}
+          onChange={(event) => onChange(event.target.value || null)}
+        />
+      </Form.Group>
+    </Col>
   );
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,13 @@
 # Configuration reference
 
-CG Arena uses [toml](https://toml.io/) format for its' config.
+New arenas store game, matchmaking, ranking, leaderboard, worker, and referee settings in the
+database. Edit them together on the web UI's **Config** page; **Apply configuration** validates
+and saves the complete candidate atomically. Invalid candidates do not replace the active
+configuration.
+
+`cgarena_config.toml` is the bootstrap file. It contains only `[server]` and `[log]`, because
+those settings are required before the HTTP application can start. The remaining sections below
+describe database-backed UI fields and their legacy TOML representation.
 
 ## `[game]`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,27 +38,18 @@ cd summer-challenge-2025
 
 ## Configuring the arena
 
-The `cgarena init` command generates the arena configuration plus the maintained Java CLI and
-Maven build patch used to produce a compatible CodinGame referee JAR:
+The `cgarena init` command creates:
 
-- `cgarena_config.toml`
-- `CommandLineInterface.java`
-- `pom_build_section.xml`
+- `cgarena_config.toml`, containing only server and logging bootstrap settings;
+- `cgarena.db`, containing arena behavior configuration and arena data.
 
-The default configuration runs `referee/target/referee.jar` directly; Python launchers are not
-required. Read the [configuration reference](configuration.md) and restart the arena after changes.
+Run the arena, open its **Local** URL, and complete the first-run form. The form validates and
+saves one complete game, matchmaking, ranking, leaderboard, embedded-worker, and referee
+configuration. Until a usable runtime is active, match, bot, matchmaking, and replay APIs report
+that the arena is unavailable while the setup page remains accessible.
 
-The default config supports c++ out of the box.
-
-The important params to configure:
-- `[game]`
-    - `min_players`: min amount of bots per match
-    - `max_players`: max amount of bots per match 
-    - `symmetric`: whether the game is symmetric
-- `[[workers]]`
-    - `threads`: amount of concurrent matches to run (check your CPU load when increasing)
-
-Refer to [this document](configuration.md) for complete configuration options.
+Read the [configuration reference](configuration.md) for every setting. Server bind and logging
+changes still require a restart because they are needed before the configuration UI starts.
 
 ## Running the arena
 
@@ -81,11 +72,8 @@ Local:   http://localhost:1234/
 Network: use 'server.expose' config param to expose
 ```
 
-Open the **Local** URL in your browser to access the web UI.
-
-The arena should initially look like this:
-
-![fresh-arena](img/fresh_arena.png)
+Open the **Local** URL in your browser. A new arena opens its first-run configuration form before
+bot submission, matchmaking, matches, or replays become available.
 
 The UI theme (light or dark) is selected based on your operating system settings.
 

--- a/migrations/20260905120000_add_arena_configuration.sql
+++ b/migrations/20260905120000_add_arena_configuration.sql
@@ -1,0 +1,4 @@
+CREATE TABLE arena_configuration (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    config_json TEXT NOT NULL
+);

--- a/src/api/errors.rs
+++ b/src/api/errors.rs
@@ -13,6 +13,8 @@ pub enum ApiError {
 
     #[error("Conflict: {0}")]
     Conflict(anyhow::Error),
+    #[error("Arena runtime is unavailable because its prerequisites are not active")]
+    RuntimeUnavailable,
 
     #[error(transparent)]
     Internal(#[from] anyhow::Error),
@@ -26,6 +28,7 @@ impl ApiError {
             ApiError::NotFound => StatusCode::NOT_FOUND,
             ApiError::ValidationFailed(_) => StatusCode::BAD_REQUEST,
             ApiError::Conflict(_) => StatusCode::CONFLICT,
+            ApiError::RuntimeUnavailable => StatusCode::SERVICE_UNAVAILABLE,
             ApiError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
             ApiError::Replay(error) => match error {
                 crate::replay_viewer::ReplayError::MatchNotFound
@@ -50,6 +53,7 @@ impl ApiError {
             ApiError::NotFound => "not_found",
             ApiError::ValidationFailed(_) => "validation_failed",
             ApiError::Conflict(_) => "already_exists",
+            ApiError::RuntimeUnavailable => "arena_unavailable",
             ApiError::Internal(_) => "internal_error",
             ApiError::Replay(error) => match error {
                 crate::replay_viewer::ReplayError::MatchNotFound

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -4,13 +4,14 @@ mod routes;
 mod web_router;
 
 use crate::api::routes::{
-    bots, charts, enable_matchmaking, fetch_status, leaderboards, matches, replays,
+    bots, charts, configuration, enable_matchmaking, fetch_status, leaderboards, matches, replays,
 };
 use crate::api::web_router::create_web_router;
 use crate::arena_handle::ArenaHandle;
 use crate::replay_viewer::ReplayViewer;
 use axum::routing::{delete, get, patch, post, put};
 use axum::Router;
+use sqlx::SqlitePool;
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 use tower_http::cors::CorsLayer;
@@ -19,14 +20,11 @@ use tracing::error;
 
 pub async fn start(
     listener: TcpListener,
-    arena_handle: ArenaHandle,
-    replay_viewer: ReplayViewer,
+    pool: SqlitePool,
+    runtime: Option<RuntimeDependencies>,
     cancellation_token: CancellationToken,
 ) {
-    let app_state = AppState {
-        arena_handle,
-        replay_viewer,
-    };
+    let app_state = AppState { pool, runtime };
     let router = create_router(app_state).await;
     let server = axum::serve(listener, router)
         .with_graceful_shutdown(async move { cancellation_token.cancelled().await });
@@ -35,12 +33,15 @@ pub async fn start(
         error!("API Server error: {}", e);
     }
 }
-
-async fn create_router(app_state: AppState) -> Router {
+pub(crate) async fn create_router(app_state: AppState) -> Router {
     let api_router = Router::new()
         .route("/bots", post(bots::create_bot))
         .route("/bots/{id}", delete(bots::delete_bot))
         .route("/bots/{id}", patch(bots::rename_bot))
+        .route(
+            "/configuration",
+            get(configuration::fetch_configuration).put(configuration::apply_configuration),
+        )
         .route("/bots/{id}/source", get(bots::fetch_source_code))
         .route("/leaderboards", post(leaderboards::create_leaderboard))
         .route("/leaderboards/{id}", patch(leaderboards::patch_leaderboard))
@@ -64,7 +65,142 @@ async fn create_router(app_state: AppState) -> Router {
 }
 
 #[derive(Clone)]
-pub(crate) struct AppState {
+pub(crate) struct RuntimeDependencies {
     pub arena_handle: ArenaHandle,
     pub replay_viewer: ReplayViewer,
+}
+
+#[derive(Clone)]
+pub(crate) struct AppState {
+    pub pool: SqlitePool,
+    runtime: Option<RuntimeDependencies>,
+}
+
+impl AppState {
+    pub fn arena_handle(&self) -> Result<&ArenaHandle, errors::ApiError> {
+        self.runtime
+            .as_ref()
+            .map(|runtime| &runtime.arena_handle)
+            .ok_or(errors::ApiError::RuntimeUnavailable)
+    }
+
+    pub fn replay_viewer(&self) -> Result<&ReplayViewer, errors::ApiError> {
+        self.runtime
+            .as_ref()
+            .map(|runtime| &runtime.replay_viewer)
+            .ok_or(errors::ApiError::RuntimeUnavailable)
+    }
+
+    pub fn runtime_available(&self) -> bool {
+        self.runtime.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::{to_bytes, Body},
+        http::{Request, StatusCode},
+    };
+    use serde_json::Value;
+    use tower::ServiceExt;
+
+    async fn setup_app() -> (Router, SqlitePool) {
+        let pool = crate::db::in_memory().await.unwrap();
+        crate::db::migrate(&pool).await.unwrap();
+        let app = create_router(AppState {
+            pool: pool.clone(),
+            runtime: None,
+        })
+        .await;
+        (app, pool)
+    }
+
+    async fn response_json(response: axum::response::Response) -> Value {
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[tokio::test]
+    async fn unconfigured_http_app_accepts_one_atomic_configuration() {
+        let (app, pool) = setup_app().await;
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/configuration")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let state = response_json(response).await;
+        assert!(state["active"].is_null());
+        assert_eq!(state["runtime_available"], false);
+
+        let mut invalid = crate::config::ArenaConfig::default();
+        invalid.workers.clear();
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/configuration")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&invalid).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert!(crate::db::fetch_arena_config(&pool)
+            .await
+            .unwrap()
+            .is_none());
+
+        let candidate = crate::config::ArenaConfig::default();
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/configuration")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&candidate).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let state = response_json(response).await;
+        assert_eq!(state["active"]["game"]["min_players"], 2);
+        assert_eq!(state["runtime_available"], false);
+        assert!(crate::db::fetch_arena_config(&pool)
+            .await
+            .unwrap()
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn runtime_routes_report_unavailable_during_setup() {
+        let (app, _) = setup_app().await;
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/status")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            response_json(response).await["error_code"],
+            "arena_unavailable"
+        );
+    }
 }

--- a/src/api/routes/bots.rs
+++ b/src/api/routes/bots.rs
@@ -35,7 +35,7 @@ pub async fn create_bot(
         .map_err(ApiError::ValidationFailed)?;
 
     let res = app_state
-        .arena_handle
+        .arena_handle()?
         .create_bot(name, source_code, language)
         .await?;
 
@@ -53,7 +53,7 @@ pub async fn delete_bot(
 ) -> Result<impl IntoResponse, ApiError> {
     let bot_id: BotId = id.into();
 
-    app_state.arena_handle.delete_bot(bot_id).await?;
+    app_state.arena_handle()?.delete_bot(bot_id).await?;
 
     Ok(StatusCode::OK)
 }
@@ -69,7 +69,7 @@ pub async fn rename_bot(
         .try_into()
         .map_err(ApiError::ValidationFailed)?;
 
-    let res = app_state.arena_handle.rename_bot(id, new_name).await?;
+    let res = app_state.arena_handle()?.rename_bot(id, new_name).await?;
 
     match res {
         RenameBotResult::Renamed => Ok(()),
@@ -86,7 +86,7 @@ pub async fn fetch_source_code(
 ) -> Result<impl IntoResponse, ApiError> {
     let id: BotId = id.into();
 
-    let res = app_state.arena_handle.fetch_bot_source_code(id).await?;
+    let res = app_state.arena_handle()?.fetch_bot_source_code(id).await?;
 
     match res {
         Some(res) => Ok(Json(BotSourceCodeResponse::from(res))),

--- a/src/api/routes/charts.rs
+++ b/src/api/routes/charts.rs
@@ -26,7 +26,7 @@ pub async fn chart(
     }
 
     let res = app_state
-        .arena_handle
+        .arena_handle()?
         .chart(filter, payload.attribute_name)
         .await?;
 

--- a/src/api/routes/configuration.rs
+++ b/src/api/routes/configuration.rs
@@ -1,0 +1,36 @@
+use axum::{extract::State, Json};
+use serde::Serialize;
+
+use crate::{
+    api::{errors::ApiError, AppState},
+    config::ArenaConfig,
+    db,
+};
+
+#[derive(Serialize)]
+pub struct ConfigurationState {
+    pub active: Option<ArenaConfig>,
+    pub runtime_available: bool,
+}
+
+pub async fn fetch_configuration(
+    State(app_state): State<AppState>,
+) -> Result<Json<ConfigurationState>, ApiError> {
+    let active = db::fetch_arena_config(&app_state.pool).await?;
+    Ok(Json(ConfigurationState {
+        active,
+        runtime_available: app_state.runtime_available(),
+    }))
+}
+
+pub async fn apply_configuration(
+    State(app_state): State<AppState>,
+    Json(candidate): Json<ArenaConfig>,
+) -> Result<Json<ConfigurationState>, ApiError> {
+    candidate.validate().map_err(ApiError::ValidationFailed)?;
+    db::persist_arena_config(&app_state.pool, &candidate).await?;
+    Ok(Json(ConfigurationState {
+        active: Some(candidate),
+        runtime_available: app_state.runtime_available(),
+    }))
+}

--- a/src/api/routes/enable_matchmaking.rs
+++ b/src/api/routes/enable_matchmaking.rs
@@ -14,7 +14,10 @@ pub async fn enable_matchmaking(
 ) -> Result<impl IntoResponse, ApiError> {
     let enabled = payload.enabled;
 
-    app_state.arena_handle.enable_matchmaking(enabled).await?;
+    app_state
+        .arena_handle()?
+        .enable_matchmaking(enabled)
+        .await?;
 
     Ok(())
 }

--- a/src/api/routes/fetch_status.rs
+++ b/src/api/routes/fetch_status.rs
@@ -8,6 +8,6 @@ use axum::Json;
 pub async fn fetch_status(
     State(app_state): State<AppState>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let res = app_state.arena_handle.fetch_status().await?;
+    let res = app_state.arena_handle()?.fetch_status().await?;
     Ok(Json(FetchStatusResponse::from(res)))
 }

--- a/src/api/routes/leaderboards.rs
+++ b/src/api/routes/leaderboards.rs
@@ -34,7 +34,7 @@ pub async fn create_leaderboard(
     let filter: MatchFilter = payload.filter.parse().map_err(ApiError::ValidationFailed)?;
 
     let res = app_state
-        .arena_handle
+        .arena_handle()?
         .create_leaderboard(name, filter)
         .await?;
 
@@ -54,7 +54,7 @@ pub async fn patch_leaderboard(
     let filter: MatchFilter = payload.filter.parse().map_err(ApiError::ValidationFailed)?;
 
     let res = app_state
-        .arena_handle
+        .arena_handle()?
         .patch_leaderboard(id, name, filter)
         .await?;
 
@@ -69,6 +69,6 @@ pub async fn delete_leaderboard(
     Path(id): Path<i64>,
 ) -> Result<impl IntoResponse, ApiError> {
     let id: LeaderboardId = id.into();
-    app_state.arena_handle.delete_leaderboard(id).await?;
+    app_state.arena_handle()?.delete_leaderboard(id).await?;
     Ok(())
 }

--- a/src/api/routes/matches.rs
+++ b/src/api/routes/matches.rs
@@ -27,7 +27,7 @@ pub async fn fetch_matches(
     let (filter, including_bots, offset, limit) = parse_request(&payload)?;
 
     let page = app_state
-        .arena_handle
+        .arena_handle()?
         .fetch_matches(MatchPageRequest {
             filter,
             including_bots,

--- a/src/api/routes/mod.rs
+++ b/src/api/routes/mod.rs
@@ -1,5 +1,6 @@
 pub mod bots;
 pub mod charts;
+pub mod configuration;
 pub mod enable_matchmaking;
 pub mod fetch_status;
 pub mod leaderboards;

--- a/src/api/routes/replays.rs
+++ b/src/api/routes/replays.rs
@@ -15,7 +15,7 @@ pub async fn watch_replay(
     State(app_state): State<AppState>,
     Path(id): Path<i64>,
 ) -> Result<Json<WatchReplayResponse>, ApiError> {
-    let replay = app_state.replay_viewer.watch(MatchId::from(id)).await?;
+    let replay = app_state.replay_viewer()?.watch(MatchId::from(id)).await?;
     Ok(Json(WatchReplayResponse {
         session_id: replay.session_id,
         viewer_url: replay.viewer_url,
@@ -26,7 +26,7 @@ pub async fn close_replay(
     State(app_state): State<AppState>,
     Path(session_id): Path<String>,
 ) -> Result<(), ApiError> {
-    app_state.replay_viewer.close(&session_id).await?;
+    app_state.replay_viewer()?.close(&session_id).await?;
     Ok(())
 }
 
@@ -34,7 +34,7 @@ pub async fn replay_asset(
     State(app_state): State<AppState>,
     Path((session_id, path)): Path<(String, String)>,
 ) -> Result<Response, ApiError> {
-    let asset = app_state.replay_viewer.asset(&session_id, &path).await?;
+    let asset = app_state.replay_viewer()?.asset(&session_id, &path).await?;
     Ok(([(header::CONTENT_TYPE, asset.content_type)], asset.bytes).into_response())
 }
 

--- a/src/arena_server.rs
+++ b/src/arena_server.rs
@@ -1,10 +1,11 @@
 use crate::arena_handle::ArenaHandle;
 use crate::cg_referee::CgReferee;
-use crate::config::{Config, WorkerConfig};
+use crate::config::{BootstrapConfig, Config, WorkerConfig};
 use crate::referee_adapter::RefereeAdapter;
 use crate::replay_viewer::ReplayViewer;
 use crate::{api, arena, db, worker};
 use anyhow::{bail, Context};
+use api::RuntimeDependencies;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::net::SocketAddr;
@@ -15,17 +16,23 @@ use tracing::{info, warn, Level};
 use tracing_subscriber::fmt::format::FmtSpan;
 
 pub async fn start(arena_path: &Path) -> anyhow::Result<()> {
-    let config = Config::load(arena_path).context("Cannot load arena config")?;
-
-    config.validate().context("Invalid config")?;
+    let bootstrap =
+        BootstrapConfig::load(arena_path).context("Cannot load bootstrap configuration")?;
 
     let log_file = OpenOptions::new()
         .append(true)
         .create(true)
-        .open(arena_path.join(config.log.file.unwrap_or("cgarena.log".to_string())))
+        .open(
+            arena_path.join(
+                bootstrap
+                    .log
+                    .file
+                    .unwrap_or_else(|| "cgarena.log".to_string()),
+            ),
+        )
         .context("Cannot write to cgarena.log")?;
 
-    let log_level = config
+    let log_level = bootstrap
         .log
         .level
         .and_then(|lvl| Level::from_str(&lvl).ok())
@@ -38,23 +45,16 @@ pub async fn start(arena_path: &Path) -> anyhow::Result<()> {
         .with_span_events(FmtSpan::CLOSE)
         .init();
 
-    if let Some(ref git_url) = config.game.referee_git_url {
-        if !git_url.is_empty() {
-            let cg_referee = CgReferee::new(git_url.clone(), arena_path.join("referee"));
-            cg_referee.ensure_initialized()?;
-        }
-    }
-    validate_referees(arena_path, &config.workers).await?;
-
     let pool = db::connect(arena_path)
         .await
         .context("Cannot connect to db")?;
+    db::migrate(&pool).await?;
     let token = CancellationToken::new();
-    let exposed = config.server.expose;
+    let exposed = bootstrap.server.expose;
     let addr = if exposed {
-        SocketAddr::from(([0, 0, 0, 0], config.server.port))
+        SocketAddr::from(([0, 0, 0, 0], bootstrap.server.port))
     } else {
-        SocketAddr::from(([127, 0, 0, 1], config.server.port))
+        SocketAddr::from(([127, 0, 0, 1], bootstrap.server.port))
     };
 
     let listener = tokio::net::TcpListener::bind(addr)
@@ -64,6 +64,19 @@ pub async fn start(arena_path: &Path) -> anyhow::Result<()> {
     let bind_addr = listener
         .local_addr()
         .context("Cannot get local address of tcp binding")?;
+
+    let Some(config) = Config::load_legacy(arena_path).context("Cannot load arena config")? else {
+        return run_setup_server(listener, pool, token, exposed, bind_addr).await;
+    };
+    config.validate().context("Invalid config")?;
+
+    if let Some(ref git_url) = config.game.referee_git_url {
+        if !git_url.is_empty() {
+            let cg_referee = CgReferee::new(git_url.clone(), arena_path.join("referee"));
+            cg_referee.ensure_initialized()?;
+        }
+    }
+    validate_referees(arena_path, &config.workers).await?;
 
     let [WorkerConfig::Embedded(cfg)] = config.workers.as_slice() else {
         bail!("In the current version only single embedded worker supported");
@@ -88,7 +101,7 @@ pub async fn start(arena_path: &Path) -> anyhow::Result<()> {
         config.matchmaking,
         config.leaderboards,
         config.ranking,
-        pool,
+        pool.clone(),
         arena_path.to_owned(),
         worker,
         arena_rx,
@@ -111,8 +124,11 @@ pub async fn start(arena_path: &Path) -> anyhow::Result<()> {
     let arena_handle = ArenaHandle::new(arena_tx);
     let mut api_task_handle = tokio::spawn(api::start(
         listener,
-        arena_handle,
-        replay_viewer.clone(),
+        pool.clone(),
+        Some(RuntimeDependencies {
+            arena_handle,
+            replay_viewer: replay_viewer.clone(),
+        }),
         token.clone(),
     ));
 
@@ -181,6 +197,45 @@ pub async fn start(arena_path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+async fn run_setup_server(
+    listener: tokio::net::TcpListener,
+    pool: sqlx::SqlitePool,
+    token: CancellationToken,
+    exposed: bool,
+    bind_addr: SocketAddr,
+) -> anyhow::Result<()> {
+    let mut api_task_handle = tokio::spawn(api::start(listener, pool, None, token.clone()));
+
+    info!("CG Arena setup started");
+    println!("CG Arena setup started, press Ctrl+C to stop it");
+    println!("Local:   http://localhost:{}/", bind_addr.port());
+    if exposed {
+        if let Ok(ip) = local_ip_address::local_ip() {
+            println!("Network: http://{}:{}/", ip, bind_addr.port());
+        }
+    } else {
+        println!("Network: use 'server.expose' config param to expose");
+    }
+    println!();
+
+    tokio::select! {
+        _ = shutdown_signal() => {
+            println!("Stopping CG Arena... press Ctrl+C again to kill it");
+        },
+        result = &mut api_task_handle => {
+            result.context("API task terminated unexpectedly")?;
+            bail!("API task terminated unexpectedly");
+        }
+    }
+
+    token.cancel();
+    api_task_handle
+        .await
+        .context("API task terminated unexpectedly")?;
+    info!("CG Arena stopped");
+    Ok(())
+}
+
 async fn validate_referees(arena_path: &Path, workers: &[WorkerConfig]) -> anyhow::Result<()> {
     for worker in workers {
         let WorkerConfig::Embedded(worker) = worker;
@@ -191,31 +246,15 @@ async fn validate_referees(arena_path: &Path, workers: &[WorkerConfig]) -> anyho
     Ok(())
 }
 
-static DEFAULT_FILES: &[(&str, &str)] = &[
-    (
-        "cgarena_config.toml",
-        include_str!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/assets/default_config.toml"
-        )),
-    ),
-    (
-        "CommandLineInterface.java",
-        include_str!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/assets/CommandLineInterface.java"
-        )),
-    ),
-    (
-        "pom_build_section.xml",
-        include_str!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/assets/pom_build_section.xml"
-        )),
-    ),
-];
+static DEFAULT_FILES: &[(&str, &str)] = &[(
+    "cgarena_config.toml",
+    include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/assets/bootstrap_config.toml"
+    )),
+)];
 
-pub fn init(path: &Path) -> anyhow::Result<()> {
+pub async fn init(path: &Path) -> anyhow::Result<()> {
     match std::fs::create_dir(path) {
         Ok(_) => (),
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => (),
@@ -231,6 +270,11 @@ pub fn init(path: &Path) -> anyhow::Result<()> {
             .write_all(content.as_bytes())
             .context(format!("Cannot write to {file}"))?;
     }
+    let pool = db::connect(path)
+        .await
+        .context("Cannot create arena database")?;
+    db::migrate(&pool).await?;
+    pool.close().await;
     println!("New arena has been initialized in {}", path.display());
     Ok(())
 }
@@ -263,25 +307,36 @@ async fn shutdown_signal() {
 mod test {
     use super::*;
 
-    #[test]
-    fn new_arena_can_be_created_in_new_folder() {
+    #[tokio::test]
+    async fn new_arena_can_be_created_in_new_folder() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test");
-        init(&path).unwrap();
-        assert!(path.join("cgarena_config.toml").exists());
-        assert!(!path.join("play_game.py").exists());
-        assert!(!path.join("watch_replay.py").exists());
-        assert!(path.join("CommandLineInterface.java").exists());
-        assert!(path.join("pom_build_section.xml").exists());
+        init(&path).await.unwrap();
+
+        let bootstrap: toml::Value =
+            toml::from_str(&std::fs::read_to_string(path.join("cgarena_config.toml")).unwrap())
+                .unwrap();
+        assert_eq!(
+            bootstrap.as_table().unwrap().keys().collect::<Vec<_>>(),
+            vec!["log", "server"]
+        );
+        assert!(path.join("cgarena.db").exists());
+        assert!(!path.join("CommandLineInterface.java").exists());
+        assert!(!path.join("pom_build_section.xml").exists());
+
+        let pool = db::connect(&path).await.unwrap();
+        db::migrate(&pool).await.unwrap();
+        assert!(db::fetch_arena_config(&pool).await.unwrap().is_none());
     }
 
-    #[test]
-    fn new_arena_can_be_created_in_existing_folder() {
+    #[tokio::test]
+    async fn new_arena_can_be_created_in_existing_folder() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test");
         std::fs::create_dir(&path).unwrap();
-        init(&path).unwrap();
+        init(&path).await.unwrap();
         assert!(path.join("cgarena_config.toml").exists());
+        assert!(path.join("cgarena.db").exists());
     }
 
     #[cfg(unix)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,24 @@ pub struct Config {
 }
 
 #[derive(Serialize, Deserialize)]
+pub struct ArenaConfig {
+    pub game: GameConfig,
+    pub matchmaking: MatchmakingConfig,
+    pub ranking: RankingConfig,
+    #[serde(default)]
+    pub leaderboards: LeaderboardsConfig,
+    pub workers: Vec<WorkerConfig>,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct BootstrapConfig {
+    #[serde(default)]
+    pub server: ServerConfig,
+    #[serde(default)]
+    pub log: LogConfig,
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct GameConfig {
     pub min_players: u32,
     pub max_players: u32,
@@ -149,89 +167,156 @@ impl Default for Config {
         toml::from_str(DEFAULT_CONFIG_CONTENT).unwrap()
     }
 }
+impl From<Config> for ArenaConfig {
+    fn from(config: Config) -> Self {
+        Self {
+            game: config.game,
+            matchmaking: config.matchmaking,
+            ranking: config.ranking,
+            leaderboards: config.leaderboards,
+            workers: config.workers,
+        }
+    }
+}
+
+impl Default for ArenaConfig {
+    fn default() -> Self {
+        Config::default().into()
+    }
+}
 
 impl Config {
-    pub fn load(arena_path: &Path) -> Result<Config, anyhow::Error> {
-        let path = arena_path.join(CONFIG_FILE_NAME);
-        let config_content = std::fs::read_to_string(path).context("Cannot open config file")?;
-        let config: Config =
+    pub fn load_legacy(arena_path: &Path) -> Result<Option<Config>, anyhow::Error> {
+        let config_content = read_config_file(arena_path)?;
+        let value: toml::Value =
             toml::from_str(&config_content).context("Config file format should be a valid TOML")?;
-        Ok(config)
+        if value.get("game").is_none() {
+            return Ok(None);
+        }
+        value
+            .try_into()
+            .map(Some)
+            .context("Config file format should be a valid arena configuration")
     }
 
     pub fn validate(&self) -> Result<(), anyhow::Error> {
-        if self.game.max_players > 8 {
-            bail!("Games with up to 8 players are supported");
-        }
-        if self.game.min_players > self.game.max_players {
-            bail!("game.max_players must be not less than game.min_players");
-        }
-        for config in &self.workers {
-            let WorkerConfig::Embedded(config) = config;
-            if config.threads == 0 {
-                bail!("embedded worker must have at least one thread");
-            }
-
-            if config.cmd_build.split_ascii_whitespace().count() == 0 {
-                bail!("cmd_build must not be blank");
-            }
-            if config.cmd_run.split_ascii_whitespace().count() == 0 {
-                bail!("cmd_run must not be blank");
-            }
-            match &config.referee {
-                RefereeConfig::CodingameJar(config) => {
-                    if config.path.trim().is_empty() {
-                        bail!("codingame_jar referee path must not be blank");
-                    }
-                    if config
-                        .java
-                        .as_deref()
-                        .is_some_and(|java| java.trim().is_empty())
-                    {
-                        bail!("codingame_jar referee java must not be blank");
-                    }
-                    if config
-                        .league
-                        .is_some_and(|league| league == 0 || league >= 20)
-                    {
-                        bail!("codingame_jar referee league must be between 1 and 19");
-                    }
-                }
-
-                RefereeConfig::Command(config) => {
-                    if config.play_match.split_ascii_whitespace().count() == 0 {
-                        bail!("command referee play_match must not be blank");
-                    }
-                    if config.watch_replay.split_ascii_whitespace().count() == 0 {
-                        bail!("command referee watch_replay must not be blank");
-                    }
-                    if !config.legacy {
-                        let play_match = shell_words::split(&config.play_match)
-                            .context("command referee play_match has invalid quoting")?;
-                        let watch_replay = shell_words::split(&config.watch_replay)
-                            .context("command referee watch_replay has invalid quoting")?;
-                        require_placeholder(&play_match, "{SEED}", "play_match")?;
-                        require_placeholder(&play_match, "{REPLAY_PATH}", "play_match")?;
-                        if !play_match.iter().any(|part| part == "{PLAYERS}") {
-                            for player in 1..=self.game.max_players {
-                                require_placeholder(
-                                    &play_match,
-                                    &format!("{{P{player}}}"),
-                                    "play_match",
-                                )?;
-                            }
-                        }
-                        for placeholder in
-                            ["{REPLAY_PATH}", "{REPLAY_DIR}", "{PORT}", "{PLAYER_COUNT}"]
-                        {
-                            require_placeholder(&watch_replay, placeholder, "watch_replay")?;
-                        }
-                    }
-                }
-            }
-        }
-        Ok(())
+        validate_arena_config(
+            &self.game,
+            &self.matchmaking,
+            &self.ranking,
+            &self.leaderboards,
+            &self.workers,
+        )
     }
+}
+
+impl ArenaConfig {
+    pub fn validate(&self) -> Result<(), anyhow::Error> {
+        validate_arena_config(
+            &self.game,
+            &self.matchmaking,
+            &self.ranking,
+            &self.leaderboards,
+            &self.workers,
+        )
+    }
+}
+
+impl BootstrapConfig {
+    pub fn load(arena_path: &Path) -> Result<Self, anyhow::Error> {
+        let config_content = read_config_file(arena_path)?;
+        toml::from_str(&config_content)
+            .context("Config file format should contain valid server and logging settings")
+    }
+}
+
+fn read_config_file(arena_path: &Path) -> anyhow::Result<String> {
+    std::fs::read_to_string(arena_path.join(CONFIG_FILE_NAME)).context("Cannot open config file")
+}
+
+fn validate_arena_config(
+    game: &GameConfig,
+    _matchmaking: &MatchmakingConfig,
+    _ranking: &RankingConfig,
+    _leaderboards: &LeaderboardsConfig,
+    workers: &[WorkerConfig],
+) -> Result<(), anyhow::Error> {
+    if game.min_players == 0 {
+        bail!("game.min_players must be at least 1");
+    }
+    if game.max_players > 8 {
+        bail!("Games with up to 8 players are supported");
+    }
+    if game.min_players > game.max_players {
+        bail!("game.max_players must be not less than game.min_players");
+    }
+    if workers.len() != 1 {
+        bail!("exactly one embedded worker must be configured");
+    }
+    for config in workers {
+        let WorkerConfig::Embedded(config) = config;
+        if config.threads == 0 {
+            bail!("embedded worker must have at least one thread");
+        }
+
+        if config.cmd_build.split_ascii_whitespace().count() == 0 {
+            bail!("cmd_build must not be blank");
+        }
+        if config.cmd_run.split_ascii_whitespace().count() == 0 {
+            bail!("cmd_run must not be blank");
+        }
+        match &config.referee {
+            RefereeConfig::CodingameJar(config) => {
+                if config.path.trim().is_empty() {
+                    bail!("codingame_jar referee path must not be blank");
+                }
+                if config
+                    .java
+                    .as_deref()
+                    .is_some_and(|java| java.trim().is_empty())
+                {
+                    bail!("codingame_jar referee java must not be blank");
+                }
+                if config
+                    .league
+                    .is_some_and(|league| league == 0 || league >= 20)
+                {
+                    bail!("codingame_jar referee league must be between 1 and 19");
+                }
+            }
+
+            RefereeConfig::Command(config) => {
+                if config.play_match.split_ascii_whitespace().count() == 0 {
+                    bail!("command referee play_match must not be blank");
+                }
+                if config.watch_replay.split_ascii_whitespace().count() == 0 {
+                    bail!("command referee watch_replay must not be blank");
+                }
+                if !config.legacy {
+                    let play_match = shell_words::split(&config.play_match)
+                        .context("command referee play_match has invalid quoting")?;
+                    let watch_replay = shell_words::split(&config.watch_replay)
+                        .context("command referee watch_replay has invalid quoting")?;
+                    require_placeholder(&play_match, "{SEED}", "play_match")?;
+                    require_placeholder(&play_match, "{REPLAY_PATH}", "play_match")?;
+                    if !play_match.iter().any(|part| part == "{PLAYERS}") {
+                        for player in 1..=game.max_players {
+                            require_placeholder(
+                                &play_match,
+                                &format!("{{P{player}}}"),
+                                "play_match",
+                            )?;
+                        }
+                    }
+                    for placeholder in ["{REPLAY_PATH}", "{REPLAY_DIR}", "{PORT}", "{PLAYER_COUNT}"]
+                    {
+                        require_placeholder(&watch_replay, placeholder, "watch_replay")?;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 fn require_placeholder(template: &[String], placeholder: &str, field: &str) -> anyhow::Result<()> {

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,7 +1,8 @@
+use crate::config::ArenaConfig;
 use crate::domain::{
     Bot, BotId, Build, BuildResult, BuildStatus, Leaderboard, LeaderboardId, Match, MatchId,
 };
-use anyhow::bail;
+use anyhow::{bail, Context};
 use chrono::{DateTime, Utc};
 use indoc::indoc;
 use sqlx::{sqlite::SqliteConnectOptions, ConnectOptions, SqlitePool};
@@ -93,6 +94,12 @@ pub async fn connect(arena_path: &Path) -> anyhow::Result<SqlitePool> {
     let pool = SqlitePool::connect_with(opts).await?;
     Ok(pool)
 }
+pub async fn migrate(pool: &SqlitePool) -> anyhow::Result<()> {
+    sqlx::migrate!()
+        .run(pool)
+        .await
+        .context("Cannot run db migrations")
+}
 
 /// for tests
 #[cfg(test)]
@@ -104,6 +111,31 @@ pub async fn in_memory() -> anyhow::Result<SqlitePool> {
         .connect("sqlite::memory:")
         .await?;
     Ok(pool)
+}
+pub async fn fetch_arena_config(pool: &SqlitePool) -> anyhow::Result<Option<ArenaConfig>> {
+    let config_json: Option<String> =
+        sqlx::query_scalar("SELECT config_json FROM arena_configuration WHERE id = 1")
+            .fetch_optional(pool)
+            .await?;
+    config_json
+        .map(|json| {
+            serde_json::from_str(&json).context("Stored arena configuration is not valid JSON")
+        })
+        .transpose()
+}
+
+pub async fn persist_arena_config(pool: &SqlitePool, config: &ArenaConfig) -> anyhow::Result<()> {
+    config.validate()?;
+    let config_json =
+        serde_json::to_string(config).context("Cannot serialize arena configuration")?;
+    sqlx::query(
+        "INSERT INTO arena_configuration (id, config_json) VALUES (1, $1) \
+         ON CONFLICT(id) DO UPDATE SET config_json = excluded.config_json",
+    )
+    .bind(config_json)
+    .execute(pool)
+    .await?;
+    Ok(())
 }
 
 pub async fn persist_bot(pool: &SqlitePool, bot: &mut Bot) -> anyhow::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ async fn handle_cli_command(command: Commands) -> anyhow::Result<()> {
     match command {
         Commands::Init { path } => {
             let path = unwrap_or_current_dir(path)?;
-            arena_server::init(&path)?;
+            arena_server::init(&path).await?;
         }
         Commands::Run { path } => {
             let path = unwrap_or_current_dir(path)?;

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,4 +1,6 @@
-use crate::config::{EmbeddedWorkerConfig, RefereeConfig};
+use crate::config::EmbeddedWorkerConfig;
+#[cfg(test)]
+use crate::config::RefereeConfig;
 use crate::domain::{
     BotId, Build, BuildResult, Language, MatchAttribute, MatchAttributeValue, Participant,
     SourceCode, WorkerName,


### PR DESCRIPTION
## Summary

- initialize new arenas with a slim server/logging bootstrap file plus a migrated SQLite database
- serve the HTTP application without arena runtime dependencies and persist one validated active configuration atomically
- add the first-run configuration UI, runtime-unavailable responses, application/frontend coverage, and updated setup documentation

## Verification

- `cargo test` — 105 passed
- `npm test` — 6 passed
- `npm run lint`
- `npm run build`
- browser smoke: initialized a temporary arena, opened the first-run page, applied a complete command-referee configuration, reloaded the persisted configuration, confirmed runtime routes return `503 arena_unavailable`, and checked desktop/mobile layout without horizontal overflow

Closes #26